### PR TITLE
Wait Specifically for PIDs instead of all commands

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -65,14 +65,11 @@ pids=""
 `, resultsDir)
 }
 
-func scriptTrailer(resultsDir string) string {
-	return fmt.Sprintf(`sleep 120 && echo "\nprocesses remaining after 120s:" >> %[1]s/out && jobs >> %[1]s/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> %[1]s/out && jobs >> %[1]s/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> %[1]s/out && jobs >> %[1]s/out &
-for pid in $pids; do
+func scriptTrailer() string {
+	return `for pid in $pids; do
     wait $pid
 done
-`, resultsDir)
+`
 }
 
 // ModelInfo represents the yaml model of an OpenConfig .spec.yml file.
@@ -230,7 +227,7 @@ func genOpenConfigValidatorScript(g labelPoster, validatorId, version string, mo
 		builder.WriteString(cmdStr)
 	}
 
-	builder.WriteString(scriptTrailer(resultsDir))
+	builder.WriteString(scriptTrailer())
 	return builder.String(), nil
 }
 

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -137,9 +137,6 @@ fi
 if ! $@ -p testdata -p /workspace/third_party/ietf testdata/optical-transport/openconfig-transport-line-protection.yang &> /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==pass; then
   mv /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==pass /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==fail
 fi
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
 for pid in $pids; do
     wait $pid
 done
@@ -159,9 +156,6 @@ fi
 if ! $@ -p testdata -p /workspace/third_party/ietf testdata/optical-transport/openconfig-transport-line-protection.yang &> /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==pass; then
   mv /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==pass /workspace/results/pyang/optical-transport==openconfig-transport-line-protection==fail
 fi
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &
 for pid in $pids; do
     wait $pid
 done
@@ -182,9 +176,6 @@ fi
 if ! $@ -p testdata -p /workspace/third_party/ietf --openconfig --ignore-error=OC_RELATIVE_PATH testdata/optical-transport/openconfig-transport-line-protection.yang &> /workspace/results/oc-pyang/optical-transport==openconfig-transport-line-protection==pass; then
   mv /workspace/results/oc-pyang/optical-transport==openconfig-transport-line-protection==pass /workspace/results/oc-pyang/optical-transport==openconfig-transport-line-protection==fail
 fi
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/oc-pyang/out && jobs >> /workspace/results/oc-pyang/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/oc-pyang/out && jobs >> /workspace/results/oc-pyang/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/oc-pyang/out && jobs >> /workspace/results/oc-pyang/out &
 for pid in $pids; do
     wait $pid
 done
@@ -208,9 +199,6 @@ if ! $@ -p testdata -p /workspace/third_party/ietf -f pybind -o /workspace/resul
   mv /workspace/results/pyangbind/optical-transport==openconfig-transport-line-protection==pass /workspace/results/pyangbind/optical-transport==openconfig-transport-line-protection==fail
 fi &
 pids+="$! "
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/pyangbind/out && jobs >> /workspace/results/pyangbind/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/pyangbind/out && jobs >> /workspace/results/pyangbind/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/pyangbind/out && jobs >> /workspace/results/pyangbind/out &
 for pid in $pids; do
     wait $pid
 done
@@ -249,9 +237,6 @@ if ! /go/bin/generator \
 testdata/optical-transport/openconfig-transport-line-protection.yang &> /workspace/results/goyang-ygot/optical-transport==openconfig-transport-line-protection==pass; then
   mv /workspace/results/goyang-ygot/optical-transport==openconfig-transport-line-protection==pass /workspace/results/goyang-ygot/optical-transport==openconfig-transport-line-protection==fail
 fi
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/goyang-ygot/out && jobs >> /workspace/results/goyang-ygot/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/goyang-ygot/out && jobs >> /workspace/results/goyang-ygot/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/goyang-ygot/out && jobs >> /workspace/results/goyang-ygot/out &
 for pid in $pids; do
     wait $pid
 done
@@ -272,9 +257,6 @@ fi
 if ! yanglint -p testdata -p /workspace/third_party/ietf testdata/optical-transport/openconfig-transport-line-protection.yang &> /workspace/results/yanglint/optical-transport==openconfig-transport-line-protection==pass; then
   mv /workspace/results/yanglint/optical-transport==openconfig-transport-line-protection==pass /workspace/results/yanglint/optical-transport==openconfig-transport-line-protection==fail
 fi
-sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/yanglint/out && jobs >> /workspace/results/yanglint/out &
-sleep 150 && echo "\nprocesses remaining after 150s:" >> /workspace/results/yanglint/out && jobs >> /workspace/results/yanglint/out &
-sleep 180 && echo "\nprocesses remaining after 180s:" >> /workspace/results/yanglint/out && jobs >> /workspace/results/yanglint/out &
 for pid in $pids; do
     wait $pid
 done

--- a/pyang-all/test.sh
+++ b/pyang-all/test.sh
@@ -146,7 +146,7 @@ if stat $PYANGBIND_RESULTSDIR; then
 
   pip3 install pyang
   {
-    if timeout 500s bash $PYANGBIND_RESULTSDIR/script.sh $VENVDIR/bin/pyang --plugindir $PYANGBIND_PLUGIN_DIR > $PYANGBIND_RESULTSDIR/$OUTFILE_NAME 2> $PYANGBIND_RESULTSDIR/$FAILFILE_NAME; then
+    if bash $PYANGBIND_RESULTSDIR/script.sh $VENVDIR/bin/pyang --plugindir $PYANGBIND_PLUGIN_DIR > $PYANGBIND_RESULTSDIR/$OUTFILE_NAME 2> $PYANGBIND_RESULTSDIR/$FAILFILE_NAME; then
       # Delete fail file if it's empty and the script passed.
       find $PYANGBIND_RESULTSDIR/$FAILFILE_NAME -size 0 -delete
     fi


### PR DESCRIPTION
This doesn't have any utility yet, though it does add the possibility of adding other parallel commands that do not gate the script's completion.

I tried to add one such command:
`sleep 120 && echo "\nprocesses remaining after 120s:" >> /workspace/results/pyang/out && jobs >> /workspace/results/pyang/out &`
`jobs` doesn't output anything for some reason -- I'll keep this for the record.