### PR TITLE
Trim space from GITHUB_ACCESS_TOKEN

### DIFF
--- a/commonci/github.go
+++ b/commonci/github.go
@@ -299,7 +299,7 @@ func NewGitHubRequestHandler() (*GithubRequestHandler, error) {
 	}
 
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: accesstk},
+		&oauth2.Token{AccessToken: strings.TrimSpace(accesstk)},
 	)
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 


### PR DESCRIPTION
For some reason GCB's new [secret decryption method](https://cloud.google.com/build/docs/securing-builds/use-encrypted-credentials#configuring_builds_to_use_encrypted_data) adds a newline to the end of the variable, so need to trim it.

This PR is a prerequisite for https://github.com/openconfig/models/pull/981