### PR TITLE
Make pyang@head run in serial to avoid ply parallelism issue

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -291,7 +291,7 @@ fi
 // runInParallel determines whether a particular validator and version should be run in parallel.
 func runInParallel(validatorId, version string) bool {
 	switch {
-	case validatorId == "goyang-ygot":
+	case validatorId == "goyang-ygot", validatorId == "pyang" && version == "head":
 		return false
 	default:
 		return true

--- a/validators/pyang/test.sh
+++ b/validators/pyang/test.sh
@@ -46,7 +46,8 @@ run-pyang-head() {
   git clone https://github.com/mbj4668/pyang.git $REPODIR
   cd $REPODIR
   echo "THIS IS PYTHONPATH: $PYTHONPATH" # debug
-  python3 setup.py install
+  source ./env.sh
+  pip3 install --no-cache-dir -r $REPODIR/requirements.txt
   if bash $RESULTSDIR/script.sh pyang > $RESULTSDIR/$OUTFILE_NAME 2> $RESULTSDIR/$FAILFILE_NAME; then
     # Delete fail file if it's empty and the script passed.
     find $RESULTSDIR/$FAILFILE_NAME -size 0 -delete
@@ -54,6 +55,7 @@ run-pyang-head() {
   $GOPATH/bin/post_results -validator=pyang -version="head" -modelRoot=$_MODEL_ROOT -repo-slug=$_REPO_SLUG -pr-number=$_PR_NUMBER -commit-sha=$COMMIT_SHA -branch=$BRANCH_NAME
 }
 
+run-pyang-head &
 for version in $(< $EXTRA_VERSIONS_FILE); do
   run-pyang-version "$version" &
 done
@@ -75,9 +77,6 @@ BADGEFILE=$RESULTSDIR/upload-badge.sh
 if stat $BADGEFILE; then
   bash $BADGEFILE
 fi
-
-wait
-run-pyang-head &
 
 ########################## CLEANUP #############################
 wait


### PR DESCRIPTION
There seems to be a [problem in ply](https://github.com/mailgun/flanker/issues/168) when running many `pyang` commands in parallel, leading to [nondeterministic failures](https://github.com/openconfig/public/pull/437#issuecomment-870764373). I'm not sure how to fix it, so I'm just going to make it run in serial. It'll run much slower but still faster than pyangbind and goyang/ygot.

Tested at https://github.com/openconfig/models/pull/1001