### PR TITLE
Documentation generation, index creation and deployment to Cloud Run.

### DIFF
--- a/docgen/main.go
+++ b/docgen/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	log "github.com/golang/glog"
+
+	"github.com/openconfig/models-ci/commonci"
+)
+
+var (
+	ocPath     = flag.String("repo_path", "", "Path to OpenConfig repo.")
+	ocpyangDir = flag.String("ocpyang_path", "", "Path to the oc-pyang repo.")
+	outputDir  = flag.String("output_path", "", "Output directory.")
+	outputFile = flag.String("output_file", "", "File to write docgen script to.")
+	outputMap  = flag.String("output_map", "", "File to write the directory map to.")
+)
+
+const (
+	docTemplate string = `
+pyang --plugindir={{ .PluginDir }}/openconfig_pyang/plugins/ \
+  -p {{ .RepoDir }} \
+  --doc-format=html \
+  -o {{ .OutputFile }} \
+  -f docs \
+  {{- $dir := .RepoDir -}}
+  {{- range $i, $file := .Files }}
+  {{- if $i }} \{{ end }}
+  {{ $dir }}/{{ $file }}
+  {{- end }}
+pyang --plugindir={{ .PluginDir }}/openconfig_pyang/plugins/ \
+  -p {{ .RepoDir }} \
+  -o {{ .OutputTree }} \
+  -f oc-jstree \
+  {{- $dir := .RepoDir -}}
+  {{- range $i, $file := .Files }}
+  {{- if $i }} \{{ end }}
+  {{ $dir }}/{{ $file }}
+  {{- end }}`
+)
+
+func main() {
+	flag.Parse()
+
+	if *ocPath == "" {
+		log.Exitf("unspecified path to openconfig/public repo.")
+	}
+
+	if *ocpyangDir == "" {
+		log.Exitf("unspecified path to openconfig/oc-pyang repo.")
+	}
+
+	if *outputDir == "" {
+		log.Exitf("unspecified output directory.")
+	}
+
+	if *outputFile == "" {
+		log.Exitf("unspecified output file.")
+	}
+
+	docsTmpl := template.Must(template.New("docs").Parse(docTemplate))
+
+	rules, err := commonci.ParseOCModels(*ocPath)
+	if err != nil {
+		log.Exitf("cannot parse models, err: %v", err)
+	}
+
+	docScript := &bytes.Buffer{}
+	docScript.WriteString("#!/bin/bash")
+
+	index := map[string]map[string]string{}
+
+	for dir, r := range rules.ModelInfoMap {
+		for _, s := range r {
+			if len(s.DocFiles) == 0 {
+				continue
+			}
+
+			opath := fmt.Sprintf("%s/%s.html", *outputDir, s.Name)
+			treepath := fmt.Sprintf("%s/%s-tree.html", *outputDir, s.Name)
+			index[s.Name] = map[string]string{
+				"docs": opath,
+				"tree": treepath,
+			}
+
+			rwFiles := []string{}
+			for _, f := range s.DocFiles {
+				rwFiles = append(rwFiles, strings.Replace(f, "yang/", "release/models/", 1))
+			}
+
+			tmp := struct {
+				RepoDir    string
+				PluginDir  string
+				OutputFile string
+				OutputTree string
+				Files      []string
+			}{
+				RepoDir:    *ocPath,
+				PluginDir:  *ocpyangDir,
+				OutputFile: opath,
+				OutputTree: treepath,
+				Files:      rwFiles,
+			}
+
+			if err := docsTmpl.Execute(docScript, tmp); err != nil {
+				log.Exitf("cannot write docs entry for rule %s->%s, err: %v", dir, s.Name, err)
+			}
+		}
+	}
+
+	js, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		log.Exitf("cannot write index file, %v", err)
+	}
+	if err := os.WriteFile(*outputMap, js, 0644); err != nil {
+		log.Exitf("cannot write site map file, %v", err)
+	}
+
+	if err := os.WriteFile(*outputFile, docScript.Bytes(), 0755); err != nil {
+		log.Exitf("cannot write output file, %v", err)
+	}
+}

--- a/docgen/main.go
+++ b/docgen/main.go
@@ -1,3 +1,6 @@
+// Binary docgen generates a script that can be used to generate openconfig
+// model documentation in pyang, along with a sitemap JSON document that can
+// be used to dynamically build an index of the generated models.
 package main
 
 import (
@@ -6,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -38,11 +42,18 @@ pyang --plugindir={{ .PluginDir }}/openconfig_pyang/plugins/ \
   -p {{ .RepoDir }} \
   -o {{ .OutputTree }} \
   -f oc-jstree \
+  --oc-jstree-strip \
   {{- $dir := .RepoDir -}}
   {{- range $i, $file := .Files }}
   {{- if $i }} \{{ end }}
   {{ $dir }}/{{ $file }}
   {{- end }}`
+)
+
+var (
+	// docsTmpl is the generated template defined based on the docTemplate
+	// constant.
+	docsTmpl = template.Must(template.New("docs").Parse(docTemplate))
 )
 
 func main() {
@@ -64,54 +75,14 @@ func main() {
 		log.Exitf("unspecified output file.")
 	}
 
-	docsTmpl := template.Must(template.New("docs").Parse(docTemplate))
-
 	rules, err := commonci.ParseOCModels(*ocPath)
 	if err != nil {
 		log.Exitf("cannot parse models, err: %v", err)
 	}
 
-	docScript := &bytes.Buffer{}
-	docScript.WriteString("#!/bin/bash")
-
-	index := map[string]map[string]string{}
-
-	for dir, r := range rules.ModelInfoMap {
-		for _, s := range r {
-			if len(s.DocFiles) == 0 {
-				continue
-			}
-
-			opath := fmt.Sprintf("%s/%s.html", *outputDir, s.Name)
-			treepath := fmt.Sprintf("%s/%s-tree.html", *outputDir, s.Name)
-			index[s.Name] = map[string]string{
-				"docs": opath,
-				"tree": treepath,
-			}
-
-			rwFiles := []string{}
-			for _, f := range s.DocFiles {
-				rwFiles = append(rwFiles, strings.Replace(f, "yang/", "release/models/", 1))
-			}
-
-			tmp := struct {
-				RepoDir    string
-				PluginDir  string
-				OutputFile string
-				OutputTree string
-				Files      []string
-			}{
-				RepoDir:    *ocPath,
-				PluginDir:  *ocpyangDir,
-				OutputFile: opath,
-				OutputTree: treepath,
-				Files:      rwFiles,
-			}
-
-			if err := docsTmpl.Execute(docScript, tmp); err != nil {
-				log.Exitf("cannot write docs entry for rule %s->%s, err: %v", dir, s.Name, err)
-			}
-		}
+	docScript, index, err := generateScript(rules, *outputDir, *ocPath, *ocpyangDir)
+	if err != nil {
+		log.Exitf("cannot generate index, err: %v", err)
 	}
 
 	js, err := json.MarshalIndent(index, "", "  ")
@@ -125,4 +96,71 @@ func main() {
 	if err := os.WriteFile(*outputFile, docScript.Bytes(), 0755); err != nil {
 		log.Exitf("cannot write output file, %v", err)
 	}
+}
+
+// indexMap is a map keyed by the name of a build rule with a value which maps
+// a label to a file path for the generated document.
+//
+// For example, if the script is called with a rule map that contains only a build
+// rule called "openconfig-foo" that generates a "doc" and "tree"
+// file in the build script, the indexMap is:
+//
+//		{
+//			"openconfig-foo": {
+//				"docs": "files/foo-docs.html",
+//				"tree": "files/foo-tree.html",
+//			}
+//		}
+type indexMap map[string]map[string]string
+
+// generateScript takes an input OpenConfigModelMap (extracted from build rules) and returns
+// a buffer containing the script to generate documentation for those models, and the index
+// as described above. If errors are encountered an error is returned.
+//
+// The script contained in the buffer uses the constant template declared above.
+func generateScript(rules commonci.OpenConfigModelMap, outdir, repodir, plugindir string) (*bytes.Buffer, indexMap, error) {
+	docScript := &bytes.Buffer{}
+	docScript.WriteString("#!/bin/bash")
+
+	index := indexMap{}
+	for dir, r := range rules.ModelInfoMap {
+		for _, s := range r {
+			if len(s.DocFiles) == 0 {
+				continue
+			}
+
+			opath := fmt.Sprintf("%s/%s.html", outdir, s.Name)
+			treepath := fmt.Sprintf("%s/%s-tree.html", outdir, s.Name)
+			index[s.Name] = map[string]string{
+				"docs": opath,
+				"tree": treepath,
+			}
+
+			rwFiles := []string{}
+			for _, f := range s.DocFiles {
+				rwFiles = append(rwFiles, strings.Replace(f, "yang/", "release/models/", 1))
+			}
+			sort.Strings(rwFiles)
+
+			tmp := struct {
+				RepoDir    string
+				PluginDir  string
+				OutputFile string
+				OutputTree string
+				Files      []string
+			}{
+				RepoDir:    repodir,
+				PluginDir:  plugindir,
+				OutputFile: opath,
+				OutputTree: treepath,
+				Files:      rwFiles,
+			}
+
+			if err := docsTmpl.Execute(docScript, tmp); err != nil {
+				return nil, nil, fmt.Errorf("cannot write docs entry for rule %s->%s, err: %v", dir, s.Name, err)
+			}
+		}
+	}
+
+	return docScript, index, nil
 }

--- a/docgen/main_test.go
+++ b/docgen/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/openconfig/models-ci/commonci"
+)
+
+func TestGenerateScript(t *testing.T) {
+	tests := []struct {
+		desc                             string
+		inMap                            commonci.OpenConfigModelMap
+		inOutDir, inRepoDir, inPluginDir string
+		wantScript                       string
+		wantIndex                        indexMap
+		wantErr                          bool
+	}{{
+		desc: "single entry",
+		inMap: commonci.OpenConfigModelMap{
+			ModelInfoMap: map[string][]commonci.ModelInfo{
+				"model": {{
+					Name:     "openconfig-model",
+					DocFiles: []string{"a.yang", "b.yang"},
+				}},
+			},
+		},
+		inOutDir:    "out",
+		inRepoDir:   "repo",
+		inPluginDir: "plugins",
+		wantScript: `#!/bin/bash
+pyang --plugindir=plugins/openconfig_pyang/plugins/ \
+  -p repo \
+  --doc-format=html \
+  -o out/openconfig-model.html \
+  -f docs \
+  repo/a.yang \
+  repo/b.yang
+pyang --plugindir=plugins/openconfig_pyang/plugins/ \
+  -p repo \
+  -o out/openconfig-model-tree.html \
+  -f oc-jstree \
+  --oc-jstree-strip \
+  repo/a.yang \
+  repo/b.yang`,
+		wantIndex: indexMap{
+			"openconfig-model": map[string]string{
+				"docs": "out/openconfig-model.html",
+				"tree": "out/openconfig-model-tree.html",
+			},
+		},
+	}, {
+		desc: "rule with no docs",
+		inMap: commonci.OpenConfigModelMap{
+			ModelInfoMap: map[string][]commonci.ModelInfo{
+				"model": {{
+					Name:       "openconfig-model",
+					BuildFiles: []string{"a.yang", "b.yang"},
+				}},
+			},
+		},
+		inOutDir:    "out",
+		inRepoDir:   "repo",
+		inPluginDir: "plugins",
+		wantScript:  `#!/bin/bash`,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			gotScript, gotIndex, err := generateScript(tt.inMap, tt.inOutDir, tt.inRepoDir, tt.inPluginDir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(gotScript.String(), tt.wantScript); diff != "" {
+				t.Fatalf("did not get expected script, difF(-got,+want):\n%s", diff)
+			}
+			if diff := cmp.Diff(gotIndex, tt.wantIndex, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("did not get expected index, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/docgen/serve/.gitignore
+++ b/docgen/serve/.gitignore
@@ -1,0 +1,4 @@
+docs.sh
+sitemap.json
+static/*
+tmp/*

--- a/docgen/serve/.gitignore
+++ b/docgen/serve/.gitignore
@@ -2,3 +2,4 @@ docs.sh
 sitemap.json
 static/*
 tmp/*
+py/*

--- a/docgen/serve/css/yangdoc.css
+++ b/docgen/serve/css/yangdoc.css
@@ -1,0 +1,99 @@
+/*
+* Copyright 2015 Google, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+h1, h2, h3, h4, h5, p {
+  color: #455A64;
+}
+
+body {
+  position: relative;
+}
+
+.module-name {
+}
+
+.module-desc-header {
+  font-weight: bold;
+}
+
+.module-desc-text {
+  // font-family: courier;
+}
+
+.module-types-header {
+
+}
+
+.module-type-name, .statement-name {
+   color: #01579B;
+}
+
+.statement-path {
+  color: #455A64;
+  font-size: 75%;
+}
+
+.module-type-text-label {
+  font-weight: bold;
+
+}
+
+.module-type-text {
+
+}
+
+.statement-section {
+  border-top: 1px solid gray;
+  margin-bottom: 10px;
+  margin: 10px 0px;
+}
+
+//.statement-name {
+//
+//}
+
+.statement-info-label {
+  font-weight: bold;
+}
+
+p.statement-info-text {
+  margin-bottom: 4px;
+
+}
+
+li a.menu-module-name {
+  color: #727272;
+}
+
+
+/* styles for scrolling nav and data panels */
+@media (min-width: 768px) {
+  .sidebar {
+    position: fixed;
+    top: 21px;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+    display: block;
+    overflow-x: hidden;
+    overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+    background-color: #f5f5f5;
+    border-right: 1px solid #eee;
+  }
+}
+
+

--- a/docgen/serve/css/yangdoc.menu.css
+++ b/docgen/serve/css/yangdoc.menu.css
@@ -1,0 +1,108 @@
+/*
+* Modifications copyright 2015 Google, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* MIT License
+*
+* Copyright (c) 2015 Sean Wessell
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*
+* Original may be obtained from bootsnipp.com
+* http://bootsnipp.com/SeanWessell/snippets/ypNAe
+*/
+
+.tree, .tree ul {
+    margin:0;
+    padding:0;
+    list-style:none
+}
+.tree ul {
+    margin-left:1em;
+    position:relative
+}
+.tree ul ul {
+    margin-left:.5em
+}
+.tree ul:before {
+    content:"";
+    display:block;
+    width:0;
+    position:absolute;
+    top:0;
+    bottom:0;
+    left:0;
+    border-left:1px solid
+}
+.tree li {
+    margin:0;
+    padding:0 1em;
+    line-height:2em;
+    color:#369;
+    font-weight:700;
+    position:relative
+}
+.tree ul li:before {
+    content:"";
+    display:block;
+    width:10px;
+    height:0;
+    border-top:1px solid;
+    margin-top:-1px;
+    position:absolute;
+    top:1em;
+    left:0
+}
+.tree ul li:last-child:before {
+    /* this background value needs to be updated if
+    *  the nav tree background color is changed
+    */
+    background:#f5f5f5;
+    height:auto;
+    top:1em;
+    bottom:0
+}
+.indicator {
+    margin-right:5px;
+}
+.tree li a {
+    text-decoration: none;
+    color:#369;
+}
+.tree li button, .tree li button:active, .tree li button:focus {
+    text-decoration: none;
+    color:#369;
+    border:none;
+    background:transparent;
+    margin:0px 0px 0px 0px;
+    padding:0px 0px 0px 0px;
+    outline: 0;
+}

--- a/docgen/serve/deploy.sh
+++ b/docgen/serve/deploy.sh
@@ -13,6 +13,5 @@ go run ../main.go -repo_path=/home/robjs/openconfig/public \
 
 ./docs.sh
 gcloud run deploy --project=disco-idea-817 --region us-west1
-
-# rm -rf tmp
-# rm docs.sh
+rm -rf tmp
+rm docs.sh

--- a/docgen/serve/deploy.sh
+++ b/docgen/serve/deploy.sh
@@ -16,9 +16,13 @@ go run ../main.go -repo_path=tmp/public \
     -output_file=docs.sh \
     -output_map=sitemap.json
 
+python3 -m venv py
+source py/bin/activate
+pip install -r tmp/oc-pyang/requirements.txt
 ./docs.sh
 
 # TODO(robjs): validate what GCP authentication details are needed here.
 gcloud run deploy --project=disco-idea-817 --region us-west1
+rm -rf py
 rm -rf tmp
 rm docs.sh

--- a/docgen/serve/deploy.sh
+++ b/docgen/serve/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mkdir tmp
+git clone https://github.com/openconfig/public tmp/public
+git clone https://github.com/openconfig/oc-pyang tmp/oc-pyang
+mkdir static
+
+go run ../main.go -repo_path=/home/robjs/openconfig/public \
+    -ocpyang_path=tmp/oc-pyang \
+    -output_path=static \
+    -output_file=docs.sh \
+    -output_map=sitemap.json
+
+./docs.sh
+gcloud run deploy --project=disco-idea-817 --region us-west1
+
+# rm -rf tmp
+# rm docs.sh

--- a/docgen/serve/deploy.sh
+++ b/docgen/serve/deploy.sh
@@ -19,6 +19,7 @@ go run ../main.go -repo_path=tmp/public \
 python3 -m venv py
 source py/bin/activate
 pip install -r tmp/oc-pyang/requirements.txt
+pip install --upgrade pyang
 ./docs.sh
 
 # TODO(robjs): validate what GCP authentication details are needed here.

--- a/docgen/serve/deploy.sh
+++ b/docgen/serve/deploy.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
+#
+# This script orchestrates generation of oc-docs and oc-jstree documentation
+# for the openconfig/public repo and deploying it directly to GCP Cloud Run.
+# 
+
 mkdir tmp
 git clone https://github.com/openconfig/public tmp/public
 git clone https://github.com/openconfig/oc-pyang tmp/oc-pyang
 mkdir static
 
-go run ../main.go -repo_path=/home/robjs/openconfig/public \
+go run ../main.go -repo_path=tmp/public \
     -ocpyang_path=tmp/oc-pyang \
     -output_path=static \
     -output_file=docs.sh \
     -output_map=sitemap.json
 
 ./docs.sh
+
+# TODO(robjs): validate what GCP authentication details are needed here.
 gcloud run deploy --project=disco-idea-817 --region us-west1
 rm -rf tmp
 rm docs.sh

--- a/docgen/serve/js/yangdoc.menu.js
+++ b/docgen/serve/js/yangdoc.menu.js
@@ -1,0 +1,88 @@
+// Modifications copyright 2015 Google, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// MIT License
+//
+// Original work Copyright (c) 2015 Sean Wessell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+// Original work may be obtained from bootsnipp.com
+// http://bootsnipp.com/SeanWessell/snippets/ypNAe
+
+$.fn.extend({
+    treed: function (o) {
+
+      var openedClass = 'glyphicon-minus-sign';
+      var closedClass = 'glyphicon-plus-sign';
+
+      if (typeof o != 'undefined'){
+        if (typeof o.openedClass != 'undefined'){
+        openedClass = o.openedClass;
+        }
+        if (typeof o.closedClass != 'undefined'){
+        closedClass = o.closedClass;
+        }
+      };
+
+    //initialize each of the top levels
+    var tree = $(this);
+    tree.addClass("tree");
+    tree.find('li').has('ul').each(function () {
+        var branch = $(this); //li with children ul
+        branch.prepend("<i class='indicator glyphicon " + closedClass + "'></i>");
+        branch.addClass('branch');
+        branch.on('click', function (e) {
+            if (this == e.target) {
+                var icon = $(this).children('i:first');
+                icon.toggleClass(openedClass + " " + closedClass);
+                $(this).children().children().toggle();
+            }
+        })
+        branch.children().children().toggle();
+    });
+    //fire event from the dynamically added icon
+  tree.find('.branch .indicator').each(function(){
+    $(this).on('click', function () {
+        $(this).closest('li').click();
+    });
+  });
+
+    tree.find('.branch>button').each(function () {
+        $(this).on('click', function (e) {
+            $(this).closest('li').click();
+            e.preventDefault();
+        });
+    });
+}
+});
+
+

--- a/docgen/serve/main.go
+++ b/docgen/serve/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"embed"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+
+	log "github.com/golang/glog"
+)
+
+//go:embed "sitemap.json"
+var fs embed.FS
+
+func main() {
+	flag.Parse()
+	sitemap := map[string]map[string]string{}
+
+	f, err := fs.ReadFile("sitemap.json")
+	if err != nil {
+		log.Exitf("cannot read sitemap, %v", err)
+	}
+	if err := json.Unmarshal(f, &sitemap); err != nil {
+		log.Exitf("cannot unmarshal sitemap, %v", err)
+	}
+
+	http.Handle("/js/", http.StripPrefix("/static/", http.FileServer(http.Dir("./js"))))
+	http.Handle("/css/", http.StripPrefix("/static/", http.FileServer(http.Dir("./css"))))
+	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("./static"))))
+	http.HandleFunc("/", mkIndex(sitemap))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Infof("defaulted to port %s", port)
+	}
+
+	log.Infof("listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatalf("cannot listen, err: %v", err)
+	}
+}
+
+func mkIndex(sitemap map[string]map[string]string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "<html><head>")
+		fmt.Fprintf(w, "<title>OpenConfig Model Documentation</title>")
+		fmt.Fprintf(w, `<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">`)
+		fmt.Fprintf(w, "</head><body>")
+		fmt.Fprintf(w, "<h1>OpenConfig Model Documentation</h1><ul>")
+
+		keys := []string{}
+		for k := range sitemap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			labels := []string{}
+			for l := range sitemap[k] {
+				labels = append(labels, l)
+			}
+			sort.Strings(labels)
+			fmt.Fprintf(w, "<li><strong>%s</strong><ul>", k)
+			for _, l := range labels {
+				fmt.Fprintf(w, `<li><a href="%s">%s</a></li>`, sitemap[k][l], l)
+			}
+			fmt.Fprintf(w, "</ul></li>")
+		}
+		fmt.Fprintf(w, "</ul></body></html>")
+	}
+}

--- a/docgen/serve/main.go
+++ b/docgen/serve/main.go
@@ -1,3 +1,9 @@
+// Binary serve creates a simple http server that serves:
+//  - a dynamically generated index written based on an input sitemap.json file (embedded using embed.FS)
+//	- a static set of files that are contained in the following subdirectories.
+//		- js
+//		- css
+//		- static
 package main
 
 import (
@@ -44,6 +50,7 @@ func main() {
 	}
 }
 
+// mkIndex generates the index HTML page.
 func mkIndex(sitemap map[string]map[string]string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "<html><head>")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openconfig/models-ci
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
```
- POC: orchestrated docs deployment to Cloud Run.
- Clean up `tmp` directory.
- Add testing and documentation.
- Deployment script updates.
- Update to pyang@latest in build script.
```

This is a basic POC of:

 * generation using commonci of a script that generates documentation for tree and OC docs from source.
 * creation of a webserver based on a simple net/http that uses the created JSON manifest to build an ops.openconfig.net style index page.
 * serving of the static files from the webserver.
 * deployment to Cloud Run.

The idea here is that we can use this to deploy containers from GitHub actions triggered on pushes the master. There are minor modifications required to do this for other branches (specifically, likely just an env var that specifies the branch to repeat this for).

Currently, this uses the disco-idea-817 project. The Cloud Run service is not currently publicly exposed.
