### PR TITLE
Make CI's displayed bash commands more usable

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -158,6 +158,7 @@ options=(
   -p {{ .RepoRoot }}/third_party/ietf
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
+  --plugindir $OCPYANG_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"
@@ -184,6 +185,7 @@ options=(
   -p {{ .ModelRoot }}
   -p {{ .RepoRoot }}/third_party/ietf
   -f pybind
+  --plugindir $PYANGBIND_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -122,7 +122,7 @@ var (
 	// GCB script, which together create the running environment for the
 	// generated validator script.
 	scriptTemplates = map[string]*scriptSpec{
-		"pyang": &scriptSpec{
+		"pyang": {
 			headerTemplate: mustTemplate("pyang-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
@@ -147,18 +147,18 @@ function run-dir() {
 			perModelTemplate: mustTemplate("pyang", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
 		},
-		"oc-pyang": &scriptSpec{
+		"oc-pyang": {
 			headerTemplate: mustTemplate("oc-pyang-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
 `+"{{`"+util.PYANG_MSG_TEMPLATE_STRING+"`}}"+`
 cmd="$@"
 options=(
-  -p {{ .ModelRoot }}
-  -p {{ .RepoRoot }}/third_party/ietf
+  --plugindir $OCPYANG_PLUGIN_DIR
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
-  --plugindir $OCPYANG_PLUGIN_DIR
+  -p {{ .ModelRoot }}
+  -p {{ .RepoRoot }}/third_party/ietf
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"
@@ -175,17 +175,17 @@ function run-dir() {
 			perModelTemplate: mustTemplate("oc-pyang", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
 		},
-		"pyangbind": &scriptSpec{
+		"pyangbind": {
 			headerTemplate: mustTemplate("pyangbind-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
 `+"{{`"+util.PYANG_MSG_TEMPLATE_STRING+"`}}"+`
 cmd="$@"
 options=(
+  --plugindir $PYANGBIND_PLUGIN_DIR
+  -f pybind
   -p {{ .ModelRoot }}
   -p {{ .RepoRoot }}/third_party/ietf
-  -f pybind
-  --plugindir $PYANGBIND_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"
@@ -203,7 +203,7 @@ function run-dir() {
 			perModelTemplate: mustTemplate("pyangbind", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
 		},
-		"goyang-ygot": &scriptSpec{
+		"goyang-ygot": {
 			headerTemplate: mustTemplate("goyang-ygot-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
@@ -241,7 +241,7 @@ function run-dir() {
 			perModelTemplate: mustTemplate("goyang-ygot", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
 		},
-		"yanglint": &scriptSpec{
+		"yanglint": {
 			headerTemplate: mustTemplate("yanglint-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
@@ -264,7 +264,7 @@ function run-dir() {
 			perModelTemplate: mustTemplate("yanglint", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
 		},
-		"confd": &scriptSpec{
+		"confd": {
 			headerTemplate: mustTemplate("confd-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
@@ -278,7 +278,7 @@ if [[ $status -eq "1" ]]; then
 fi
 `),
 		},
-		"misc-checks": &scriptSpec{
+		"misc-checks": {
 			headerTemplate: mustTemplate("misc-checks-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -154,7 +154,6 @@ mkdir -p "$workdir"
 `+"{{`"+util.PYANG_MSG_TEMPLATE_STRING+"`}}"+`
 cmd="$@"
 options=(
-  --plugindir $OCPYANG_PLUGIN_DIR
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
   -p {{ .ModelRoot }}
@@ -165,8 +164,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
+  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
+  local cmd_display_options=( --plugindir '$OCPYANG_PLUGIN_DIR' "${options[@]}" )
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi
@@ -182,7 +183,6 @@ mkdir -p "$workdir"
 `+"{{`"+util.PYANG_MSG_TEMPLATE_STRING+"`}}"+`
 cmd="$@"
 options=(
-  --plugindir $PYANGBIND_PLUGIN_DIR
   -f pybind
   -p {{ .ModelRoot }}
   -p {{ .RepoRoot }}/third_party/ietf
@@ -192,9 +192,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( -o "$1"."$2".binding.py "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
+  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -138,7 +138,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -164,10 +164,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
   local cmd_display_options=( --plugindir '$OCPYANG_PLUGIN_DIR' "${options[@]}" )
+  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
   shift 2
-  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi
@@ -192,10 +192,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
-  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -116,7 +116,6 @@ mkdir -p "$workdir"
 PYANG_MSG_TEMPLATE='messages:{{path:"{file}" line:{line} code:"{code}" type:"{type}" level:{level} message:'"'{msg}'}}"
 cmd="$@"
 options=(
-  --plugindir $OCPYANG_PLUGIN_DIR
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
   -p testdata
@@ -127,8 +126,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
+  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
+  local cmd_display_options=( --plugindir '$OCPYANG_PLUGIN_DIR' "${options[@]}" )
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi
@@ -148,7 +149,6 @@ mkdir -p "$workdir"
 PYANG_MSG_TEMPLATE='messages:{{path:"{file}" line:{line} code:"{code}" type:"{type}" level:{level} message:'"'{msg}'}}"
 cmd="$@"
 options=(
-  --plugindir $PYANGBIND_PLUGIN_DIR
   -f pybind
   -p testdata
   -p /workspace/third_party/ietf
@@ -158,9 +158,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( -o "$1"."$2".binding.py "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
+  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -116,11 +116,11 @@ mkdir -p "$workdir"
 PYANG_MSG_TEMPLATE='messages:{{path:"{file}" line:{line} code:"{code}" type:"{type}" level:{level} message:'"'{msg}'}}"
 cmd="$@"
 options=(
-  -p testdata
-  -p /workspace/third_party/ietf
+  --plugindir $OCPYANG_PLUGIN_DIR
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
-  --plugindir $OCPYANG_PLUGIN_DIR
+  -p testdata
+  -p /workspace/third_party/ietf
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"
@@ -148,10 +148,10 @@ mkdir -p "$workdir"
 PYANG_MSG_TEMPLATE='messages:{{path:"{file}" line:{line} code:"{code}" type:"{type}" level:{level} message:'"'{msg}'}}"
 cmd="$@"
 options=(
+  --plugindir $PYANGBIND_PLUGIN_DIR
+  -f pybind
   -p testdata
   -p /workspace/third_party/ietf
-  -f pybind
-  --plugindir $PYANGBIND_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -120,6 +120,7 @@ options=(
   -p /workspace/third_party/ietf
   --openconfig
   --ignore-error=OC_RELATIVE_PATH
+  --plugindir $OCPYANG_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"
@@ -150,6 +151,7 @@ options=(
   -p testdata
   -p /workspace/third_party/ietf
   -f pybind
+  --plugindir $PYANGBIND_PLUGIN_DIR
 )
 script_options=(
   --msg-template "$PYANG_MSG_TEMPLATE"

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -126,10 +126,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
   local cmd_display_options=( --plugindir '$OCPYANG_PLUGIN_DIR' "${options[@]}" )
+  local options=( --plugindir "$OCPYANG_PLUGIN_DIR" "${options[@]}" )
   shift 2
-  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi
@@ -158,10 +158,10 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
-  echo $cmd "${cmd_display_options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -66,7 +66,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi
@@ -97,7 +97,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   shift 2
-  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  echo pyang "${options[@]}" "$@" > ${prefix}cmd
   if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
     mv ${prefix}pass ${prefix}fail
   fi

--- a/post_results/main.go
+++ b/post_results/main.go
@@ -438,6 +438,12 @@ func processPyangOutput(rawOut string, pass, noWarnings bool) (string, error) {
 	return out.String(), nil
 }
 
+// userfyBashCommand changes the bash command displayed to the user to be
+// something that's easier to use.
+func userfyBashCommand(cmd string) string {
+	return strings.NewReplacer("/workspace/", "$WORKSPACE/", "$OCPYANG_PLUGIN_DIR", "$GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins", "$PYANGBIND_PLUGIN_DIR", "$GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin").Replace(cmd)
+}
+
 // parseModelResultsHTML transforms the output files of the validator script into HTML
 // to be displayed on GitHub.
 // If condensed=true, then only errors are provided.
@@ -489,7 +495,7 @@ func parseModelResultsHTML(validatorId, validatorResultDir string, condensed boo
 				// order, ${prefix}cmd should be walked first,
 				// such that ${prefix}pass or ${prefix}fail
 				// will have it ready to display to the user.
-				bashCommand = outString
+				bashCommand = userfyBashCommand(outString)
 				bashCommandModelDirName = modelDirName
 				bashCommandModelName = modelName
 				return nil
@@ -525,7 +531,7 @@ func parseModelResultsHTML(validatorId, validatorResultDir string, condensed boo
 				// Display bash command that produced the validator result.
 				var bashCommandSummary string
 				if bashCommand != "" && bashCommandModelDirName == modelDirName && bashCommandModelName == modelName {
-					bashCommandSummary = sprintSummaryHTML("cmd", "bash command", "<pre>%s</pre>", bashCommand)
+					bashCommandSummary = fmt.Sprintf("%s&nbsp; %s\n<pre>%s</pre>\n", commonci.Emoji("cmd"), "bash command", bashCommand)
 				}
 				modelHTML.WriteString(sprintSummaryHTML(status, modelName, bashCommandSummary+outString))
 			}
@@ -711,7 +717,7 @@ func postCompatibilityReport(validatorAndVersions []commonci.ValidatorAndVersion
 		gistTitle := fmt.Sprintf("%s %s", commonci.Emoji(commonci.BoolStatusToString(pass)), validatorDescs[i])
 		id, err := g.AddGistComment(gistID, gistTitle, testResultString)
 		if err != nil {
-			fmt.Errorf("postResult: could not add gist comment: %v", err)
+			return fmt.Errorf("postResult: could not add gist comment: %v", err)
 		}
 
 		commentBuilder.WriteString(fmt.Sprintf("%s [%s](%s#gistcomment-%d)\n", commonci.Emoji(commonci.BoolStatusToString(pass)), validatorDescs[i], gistURL, id))
@@ -820,7 +826,7 @@ func postResult(validatorId, version string) error {
 
 	// Post parsed test results as a gist comment.
 	if _, err := g.AddGistComment(gistID, fmt.Sprintf("%s %s", commonci.Emoji(commonci.BoolStatusToString(pass)), validatorDesc), testResultString); err != nil {
-		fmt.Errorf("postResult: could not add gist comment: %v", err)
+		return fmt.Errorf("postResult: could not add gist comment: %v", err)
 	}
 
 	prUpdate := &commonci.GithubPRUpdate{

--- a/post_results/main.go
+++ b/post_results/main.go
@@ -441,7 +441,7 @@ func processPyangOutput(rawOut string, pass, noWarnings bool) (string, error) {
 // userfyBashCommand changes the bash command displayed to the user to be
 // something that's easier to use.
 func userfyBashCommand(cmd string) string {
-	return strings.NewReplacer("/workspace/", "$WORKSPACE/", "$OCPYANG_PLUGIN_DIR", "$GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins", "$PYANGBIND_PLUGIN_DIR", "$GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin").Replace(cmd)
+	return strings.NewReplacer("/workspace/", "$OC_WORKSPACE/", "$OCPYANG_PLUGIN_DIR", "$GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins", "$PYANGBIND_PLUGIN_DIR", "$GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin").Replace(cmd)
 }
 
 // parseModelResultsHTML transforms the output files of the validator script into HTML

--- a/post_results/main_test.go
+++ b/post_results/main_test.go
@@ -222,7 +222,7 @@ func TestGetResult(t *testing.T) {
   <summary>&#x2705;&nbsp; openconfig-acl</summary>
 &#x1F4B2;&nbsp; bash command
 <pre>foo command
-$WORKSPACE/foo/bar
+$OC_WORKSPACE/foo/bar
 $GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins
 $GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin
 </pre>
@@ -265,7 +265,7 @@ Test failed with no stderr output.`,
   <summary>&#x2705;&nbsp; openconfig-acl</summary>
 &#x1F4B2;&nbsp; bash command
 <pre>foo command
-$WORKSPACE/foo/bar
+$OC_WORKSPACE/foo/bar
 $GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins
 $GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin
 </pre>

--- a/post_results/main_test.go
+++ b/post_results/main_test.go
@@ -220,10 +220,12 @@ func TestGetResult(t *testing.T) {
   <summary>&#x2705;&nbsp; acl</summary>
 <details>
   <summary>&#x2705;&nbsp; openconfig-acl</summary>
-<details>
-  <summary>&#x1F4B2;&nbsp; bash command</summary>
+&#x1F4B2;&nbsp; bash command
 <pre>foo command
-</pre></details>
+$WORKSPACE/foo/bar
+$GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins
+$GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin
+</pre>
 Passed.
 </details>
 </details>
@@ -261,10 +263,12 @@ Test failed with no stderr output.`,
   <summary>&#x2705;&nbsp; acl</summary>
 <details>
   <summary>&#x2705;&nbsp; openconfig-acl</summary>
-<details>
-  <summary>&#x1F4B2;&nbsp; bash command</summary>
+&#x1F4B2;&nbsp; bash command
 <pre>foo command
-</pre></details>
+$WORKSPACE/foo/bar
+$GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins
+$GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin
+</pre>
 Passed.
 </details>
 </details>

--- a/post_results/testdata/oc-pyang/acl==openconfig-acl==cmd
+++ b/post_results/testdata/oc-pyang/acl==openconfig-acl==cmd
@@ -1,1 +1,4 @@
 foo command
+/workspace/foo/bar
+$OCPYANG_PLUGIN_DIR
+$PYANGBIND_PLUGIN_DIR

--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -61,7 +61,7 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang --plugindir $OCPYANG_PLUGIN_DIR > $OUTFILE 2> $FAILFILE; then
+if OCPYANG_PLUGIN_DIR=$OCPYANG_PLUGIN_DIR bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi

--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -61,7 +61,7 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-if OCPYANG_PLUGIN_DIR=$OCPYANG_PLUGIN_DIR bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
+if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi

--- a/validators/pyangbind/test.sh
+++ b/validators/pyangbind/test.sh
@@ -50,7 +50,7 @@ find $RESULTSDIR/latest-version.txt -size 0 -delete
 
 export PYANGBIND_PLUGIN_DIR=`/usr/bin/env python3 -c \
   'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
-if PYANGBIND_PLUGIN_DIR=$PYANGBIND_PLUGIN_DIR bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
+if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi

--- a/validators/pyangbind/test.sh
+++ b/validators/pyangbind/test.sh
@@ -50,7 +50,7 @@ find $RESULTSDIR/latest-version.txt -size 0 -delete
 
 export PYANGBIND_PLUGIN_DIR=`/usr/bin/env python3 -c \
   'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
-if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang --plugindir $PYANGBIND_PLUGIN_DIR > $OUTFILE 2> $FAILFILE; then
+if PYANGBIND_PLUGIN_DIR=$PYANGBIND_PLUGIN_DIR bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi


### PR DESCRIPTION
New displayed commands:
```
pyang --plugindir $GOPATH/src/github.com/openconfig/oc-pyang/openconfig_pyang/plugins --openconfig --ignore-error=OC_RELATIVE_PATH -p $WORKSPACE/release/models -p $WORKSPACE/third_party/ietf $WORKSPACE/release/models/acl/openconfig-acl.yang
```
```
pyang --plugindir $GOPATH/src/github.com/robshakir/pyangbind/pyangbind/plugin -o acl.openconfig-acl.binding.py -f pybind -p $WORKSPACE/release/models -p $WORKSPACE/third_party/ietf $WORKSPACE/release/models/acl/openconfig-acl.yang
```

Passing build: https://github.com/openconfig/public/pull/740