### PR TITLE
Use `$_OC_PYANG_VERSION` to determine which OC linter version to run

### DIFF
--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -35,7 +35,8 @@ setup() {
 
   git clone https://github.com/openconfig/oc-pyang $OCPYANG_REPO -b $_OC_PYANG_VERSION
   cd $OCPYANG_REPO
-  git rev-parse --short HEAD > $RESULTSDIR/latest-version.txt
+  echo -n "Running version " >> $OUTFILE
+  git rev-parse --short HEAD >> $OUTFILE
   cd ..
   pip3 install --no-cache-dir -r $OCPYANG_DIR/requirements.txt
   pip3 install --no-cache-dir -r $OCPYANG_REPO/requirements.txt
@@ -64,7 +65,7 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
+if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang >> $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi

--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -33,7 +33,7 @@ setup() {
   virtualenv $VENVDIR
   source $VENVDIR/bin/activate
 
-  git clone https://github.com/openconfig/oc-pyang $OCPYANG_REPO
+  git clone https://github.com/openconfig/oc-pyang $OCPYANG_REPO -b $_OC_PYANG_VERSION
   pip3 install --no-cache-dir -r $OCPYANG_DIR/requirements.txt
   pip3 install --no-cache-dir -r $OCPYANG_REPO/requirements.txt
   pip3 install setuptools

--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -35,7 +35,7 @@ setup() {
 
   git clone https://github.com/openconfig/oc-pyang $OCPYANG_REPO -b $_OC_PYANG_VERSION
   cd $OCPYANG_REPO
-  echo -n "Running version " >> $OUTFILE
+  echo -n "Running at github.com/openconfig/oc-pyang branch " >> $OUTFILE
   git rev-parse --short HEAD >> $OUTFILE
   cd ..
   pip3 install --no-cache-dir -r $OCPYANG_DIR/requirements.txt

--- a/validators/oc-pyang/test.sh
+++ b/validators/oc-pyang/test.sh
@@ -34,6 +34,9 @@ setup() {
   source $VENVDIR/bin/activate
 
   git clone https://github.com/openconfig/oc-pyang $OCPYANG_REPO -b $_OC_PYANG_VERSION
+  cd $OCPYANG_REPO
+  git rev-parse --short HEAD > $RESULTSDIR/latest-version.txt
+  cd ..
   pip3 install --no-cache-dir -r $OCPYANG_DIR/requirements.txt
   pip3 install --no-cache-dir -r $OCPYANG_REPO/requirements.txt
   pip3 install setuptools


### PR DESCRIPTION
This allows openconfig/public test PRs to run against a different version of the OC linter to do test runs this version is then output in the linter output.

See https://github.com/openconfig/public/pull/837/files#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5cR2 for how to use.