### PR TITLE
Don't report v0->v1 as breaking changes.

### DIFF
--- a/post_results/main.go
+++ b/post_results/main.go
@@ -226,104 +226,6 @@ func checkSemverIncrease(oldVersion, newVersion, versionStringName string) (*sem
 	}
 }
 
-// processMiscChecksOutput takes the raw result output from the misc-checks
-// results directory and returns its formatted report and pass/fail status.
-//
-// It also returns a newline-separated string of the list of all YANG files
-// that have their major versions updated.
-func processMiscChecksOutput(resultsDir string) (string, bool, string, error) {
-	fileProperties := map[string]map[string]string{}
-	changedFiles, err := readYangFilesList(filepath.Join(resultsDir, "changed-files.txt"))
-	if err != nil {
-		return "", false, "", err
-	}
-	for _, file := range changedFiles {
-		if _, ok := fileProperties[file]; !ok {
-			fileProperties[file] = map[string]string{}
-		}
-		fileProperties[file]["changed"] = "true"
-	}
-	if err := readGoyangVersionsLog(filepath.Join(resultsDir, "pr-file-parse-log"), false, fileProperties); err != nil {
-		return "", false, "", err
-	}
-	if err := readGoyangVersionsLog(filepath.Join(resultsDir, "master-file-parse-log"), true, fileProperties); err != nil {
-		return "", false, "", err
-	}
-
-	var ocVersionViolations []string
-	ocVersionChangedCount := 0
-	var reachabilityViolations []string
-	filesReachedCount := 0
-	// Only look at the PR's files as they might be different from the master's files.
-	allNonEmptyPRFiles, err := readYangFilesList(filepath.Join(resultsDir, "all-non-empty-files.txt"))
-	if err != nil {
-		return "", false, "", err
-	}
-	moduleFileGroups := map[string][]fileAndVersion{}
-	var majorVersionChanges strings.Builder
-	for _, file := range allNonEmptyPRFiles {
-		properties, ok := fileProperties[file]
-
-		// Reachability check
-		if !ok || properties["reachable"] != "true" {
-			reachabilityViolations = append(reachabilityViolations, sprintLineHTML("%s: file not used by any .spec.yml build.", file))
-			// If the file was not reached, then its other
-			// parameters would not have been parsed by goyang, so
-			// simply skip the rest of the checks.
-			continue
-		}
-		filesReachedCount += 1
-
-		// openconfig-version update check
-		ocVersion, hasVersion := properties["openconfig-version"]
-		masterOcVersion, hadVersion := properties["master-openconfig-version"]
-		switch {
-		case properties["changed"] != "true":
-			// We assume the versioning is correct without change.
-		case hadVersion && hasVersion:
-			oldver, newver, err := checkSemverIncrease(masterOcVersion, ocVersion, "openconfig-version")
-			if err != nil {
-				ocVersionViolations = append(ocVersionViolations, sprintLineHTML(file+": "+err.Error()))
-			} else {
-				ocVersionChangedCount += 1
-			}
-			if oldver != nil && newver != nil {
-				if oldver.Major() != newver.Major() {
-					majorVersionChanges.WriteString(fmt.Sprintf("%s: `%s` -> `%s`\n", file, masterOcVersion, ocVersion))
-				}
-			}
-		case hadVersion && !hasVersion:
-			ocVersionViolations = append(ocVersionViolations, sprintLineHTML("%s: openconfig-version was removed", file))
-		default: // If didn't have version before, any new version is accepted.
-			ocVersionChangedCount += 1
-		}
-
-		if mod, ok := properties["belonging-module"]; hasVersion && ok {
-			// Error checking is already done by the version update check.
-			if v, err := semver.StrictNewVersion(ocVersion); err == nil {
-				moduleFileGroups[mod] = append(moduleFileGroups[mod], fileAndVersion{name: file, version: v})
-			}
-		}
-	}
-
-	// Compute HTML string and pass/fail status.
-	var out strings.Builder
-	var pass = true
-	appendViolationOut := func(desc string, violations []string, passString string) {
-		if len(violations) == 0 {
-			out.WriteString(sprintSummaryHTML(commonci.BoolStatusToString(true), desc, passString))
-		} else {
-			out.WriteString(sprintSummaryHTML(commonci.BoolStatusToString(false), desc, strings.Join(violations, "")))
-			pass = false
-		}
-	}
-	appendViolationOut("openconfig-version update check", ocVersionViolations, fmt.Sprintf("%d file(s) correctly updated.\n", ocVersionChangedCount))
-	appendViolationOut(".spec.yml build reachability check", reachabilityViolations, fmt.Sprintf("%d files reached by build rules.\n", filesReachedCount))
-	appendViolationOut("submodule versions must match the belonging module's version", versionGroupViolationsHTML(moduleFileGroups), fmt.Sprintf("%d module/submodule file groups have matching versions", len(moduleFileGroups)))
-
-	return out.String(), pass, majorVersionChanges.String(), nil
-}
-
 type fileAndVersion struct {
 	name    string
 	version *semver.Version
@@ -568,18 +470,18 @@ func parseModelResultsHTML(validatorId, validatorResultDir string, condensed boo
 // version changes.
 //
 // If condensed=true, then only errors are provided.
-func getResult(validatorId, resultsDir string, condensed bool) (string, bool, string, error) {
+func getResult(validatorId, resultsDir string, condensed bool) (string, bool, majorVersionChangeSlice, error) {
 	validator, ok := commonci.Validators[validatorId]
 	if !ok {
-		return "", false, "", fmt.Errorf("validator %q not found!", validatorId)
+		return "", false, nil, fmt.Errorf("validator %q not found!", validatorId)
 	}
 
 	// outString is parsed stdout.
 	var outString string
 	// pass is the overall validation result.
 	var pass bool
-	// majorVersionChanges is a GitHub-formatted string listing major YANG version changes.
-	var majorVersionChanges string
+	// majorVersionChanges contains all information regarding listing major YANG version changes.
+	var majorVersionChanges majorVersionChangeSlice
 
 	failFileBytes, err := ioutil.ReadFile(filepath.Join(resultsDir, commonci.FailFileName))
 	// existent fail file == failure.
@@ -748,23 +650,21 @@ func postCompatibilityReport(validatorAndVersions []commonci.ValidatorAndVersion
 
 // postBreakingChangeLabel posts label and information on whether the PR
 // contains breaking changes that necessitate a repository version bump.
-func postBreakingChangeLabel(g *commonci.GithubRequestHandler, majorVersionChanges string) error {
-	var majorVersionChangesComment string
-	switch majorVersionChanges {
-	case "":
-		majorVersionChangesComment = fmt.Sprintf("No major YANG version changes in commit %s", commitSHA)
+func postBreakingChangeLabel(g *commonci.GithubRequestHandler, majorVersionChanges majorVersionChangeSlice) error {
+	if majorVersionChanges.hasBreaking() {
 		if err := g.PostLabel("non-breaking", "00FF00", owner, repo, prNumber); err != nil {
 			return fmt.Errorf("couldn't post label: %v", err)
 		}
 		// Don't error out on error since it's possible the label doesn't exist.
 		g.DeleteLabel("breaking", owner, repo, prNumber)
-	default:
-		majorVersionChangesComment = fmt.Sprintf("Major YANG version changes in commit %s:\n%s", commitSHA, majorVersionChanges)
+	} else {
 		if err := g.PostLabel("breaking", "FF0000", owner, repo, prNumber); err != nil {
 			return fmt.Errorf("couldn't post label: %v", err)
 		}
 		g.DeleteLabel("non-breaking", owner, repo, prNumber)
 	}
+	// NOTE: "ajor" is not a typo.
+	majorVersionChangesComment := majorVersionChanges.String()
 	if err := g.AddEditOrDeletePRComment("ajor YANG version changes in commit", &majorVersionChangesComment, owner, repo, prNumber); err != nil {
 		return fmt.Errorf("couldn't post major YANG version changes comment: %v", err)
 	}

--- a/post_results/main_test.go
+++ b/post_results/main_test.go
@@ -218,7 +218,7 @@ func TestGetResult(t *testing.T) {
 		wantOut                 string
 		wantCondensedOut        string
 		wantCondensedOutSame    bool
-		wantMajorVersionChanges string
+		wantMajorVersionChanges majorVersionChangeSlice
 		wantErrSubstr           string
 	}{{
 		name:                 "basic pyang pass",
@@ -457,11 +457,21 @@ Failed.
 		wantOut:              "Validator script failed -- infra bug?\nI failed\n",
 		wantCondensedOutSame: true,
 	}, {
-		name:                    "openconfig-version, revision version, and .spec.yml checks all pass",
-		inValidatorResultDir:    "testdata/misc-checks-pass",
-		inValidatorId:           "misc-checks",
-		wantPass:                true,
-		wantMajorVersionChanges: "openconfig-interface-submodule.yang: `0.5.0` -> `1.0.0`\nopenconfig-interface.yang: `1.1.3` -> `2.0.0`\n",
+		name:                 "openconfig-version, revision version, and .spec.yml checks all pass",
+		inValidatorResultDir: "testdata/misc-checks-pass",
+		inValidatorId:        "misc-checks",
+		wantPass:             true,
+		wantMajorVersionChanges: majorVersionChangeSlice{{
+			File:            "openconfig-interface-submodule.yang",
+			OldMajorVersion: 0,
+			OldVersion:      "0.5.0",
+			NewVersion:      "1.0.0",
+		}, {
+			File:            "openconfig-interface.yang",
+			OldMajorVersion: 1,
+			OldVersion:      "1.1.3",
+			NewVersion:      "2.0.0",
+		}},
 		wantOut: `<details>
   <summary>&#x2705;&nbsp; openconfig-version update check</summary>
 9 file(s) correctly updated.

--- a/post_results/main_test.go
+++ b/post_results/main_test.go
@@ -207,19 +207,75 @@ func TestCheckSemverIncrease(t *testing.T) {
 	}
 }
 
+func TestVersionRecords(t *testing.T) {
+	tests := []struct {
+		desc             string
+		inVersionRecords versionRecordSlice
+		wantHasBreaking  bool
+	}{{
+		desc: "has breaking",
+		inVersionRecords: versionRecordSlice{{
+			File:            "openconfig-interface-submodule.yang",
+			OldMajorVersion: 0,
+			NewMajorVersion: 1,
+			OldVersion:      "0.5.0",
+			NewVersion:      "1.0.0",
+		}, {
+			File:            "openconfig-interface.yang",
+			OldMajorVersion: 1,
+			NewMajorVersion: 2,
+			OldVersion:      "1.1.3",
+			NewVersion:      "2.0.0",
+		}},
+		wantHasBreaking: true,
+	}, {
+		desc: "non-breaking",
+		inVersionRecords: versionRecordSlice{{
+			File:            "openconfig-interface-submodule.yang",
+			OldMajorVersion: 0,
+			NewMajorVersion: 1,
+			OldVersion:      "0.5.0",
+			NewVersion:      "1.0.0",
+		}},
+		wantHasBreaking: false,
+	}, {
+		desc: "non-breaking",
+		inVersionRecords: versionRecordSlice{{
+			File:            "openconfig-interface-submodule.yang",
+			OldMajorVersion: 1,
+			NewMajorVersion: 1,
+			OldVersion:      "1.5.0",
+			NewVersion:      "1.6.0",
+		}},
+		wantHasBreaking: false,
+	}, {
+		desc:             "empty",
+		inVersionRecords: nil,
+		wantHasBreaking:  false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if gotHasBreaking, want := tt.inVersionRecords.hasBreaking(), tt.wantHasBreaking; gotHasBreaking != want {
+				t.Errorf("gotHasBreaking %v, want %v", gotHasBreaking, want)
+			}
+		})
+	}
+}
+
 func TestGetResult(t *testing.T) {
 	modelRoot = "/workspace/release/yang"
 
 	tests := []struct {
-		name                    string
-		inValidatorResultDir    string
-		inValidatorId           string
-		wantPass                bool
-		wantOut                 string
-		wantCondensedOut        string
-		wantCondensedOutSame    bool
-		wantMajorVersionChanges majorVersionChangeSlice
-		wantErrSubstr           string
+		name                   string
+		inValidatorResultDir   string
+		inValidatorId          string
+		wantPass               bool
+		wantOut                string
+		wantCondensedOut       string
+		wantCondensedOutSame   bool
+		wantVersionRecordSlice versionRecordSlice
+		wantErrSubstr          string
 	}{{
 		name:                 "basic pyang pass",
 		inValidatorResultDir: "testdata/oc-pyang",
@@ -461,16 +517,36 @@ Failed.
 		inValidatorResultDir: "testdata/misc-checks-pass",
 		inValidatorId:        "misc-checks",
 		wantPass:             true,
-		wantMajorVersionChanges: majorVersionChangeSlice{{
+		wantVersionRecordSlice: versionRecordSlice{{
+			File:            "openconfig-acl-submodule.yang",
+			OldMajorVersion: 1,
+			NewMajorVersion: 1,
+			OldVersion:      "1.1.3",
+			NewVersion:      "1.2.3",
+		}, {
+			File:            "openconfig-acl.yang",
+			OldMajorVersion: 1,
+			NewMajorVersion: 1,
+			OldVersion:      "1.2.2",
+			NewVersion:      "1.2.3",
+		}, {
 			File:            "openconfig-interface-submodule.yang",
 			OldMajorVersion: 0,
+			NewMajorVersion: 1,
 			OldVersion:      "0.5.0",
 			NewVersion:      "1.0.0",
 		}, {
 			File:            "openconfig-interface.yang",
 			OldMajorVersion: 1,
+			NewMajorVersion: 2,
 			OldVersion:      "1.1.3",
 			NewVersion:      "2.0.0",
+		}, {
+			File:            "openconfig-packet-match.yang",
+			OldMajorVersion: 1,
+			NewMajorVersion: 1,
+			OldVersion:      "1.1.2",
+			NewVersion:      "1.2.0",
 		}},
 		wantOut: `<details>
   <summary>&#x2705;&nbsp; openconfig-version update check</summary>
@@ -514,7 +590,7 @@ Failed.
 	for _, tt := range tests {
 		for _, condensed := range []bool{false, true} {
 			t.Run(fmt.Sprintf(tt.name+"@condensed=%v", condensed), func(t *testing.T) {
-				gotOut, gotPass, majorVersionChanges, err := getResult(tt.inValidatorId, tt.inValidatorResultDir, condensed)
+				gotOut, gotPass, versionRecords, err := getResult(tt.inValidatorId, tt.inValidatorResultDir, condensed)
 				if err != nil {
 					if diff := errdiff.Substring(err, tt.wantErrSubstr); diff != "" {
 						t.Fatalf("did not get expected error, %s", diff)
@@ -524,8 +600,8 @@ Failed.
 				if gotPass != tt.wantPass {
 					t.Errorf("gotPass %v, want %v", gotPass, tt.wantPass)
 				}
-				if diff := cmp.Diff(tt.wantMajorVersionChanges, majorVersionChanges); diff != "" {
-					t.Errorf("majorVersionChanges (-want, +got):\n%s", diff)
+				if diff := cmp.Diff(tt.wantVersionRecordSlice, versionRecords); diff != "" {
+					t.Errorf("versionRecords (-want, +got):\n%s", diff)
 				}
 				wantOut := tt.wantOut
 				if condensed && !tt.wantCondensedOutSame {

--- a/post_results/misc-checks.go
+++ b/post_results/misc-checks.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/openconfig/models-ci/commonci"
+)
+
+type majorVersionChange struct {
+	File            string
+	OldMajorVersion uint64
+	OldVersion      string
+	NewVersion      string
+}
+
+type majorVersionChangeSlice []majorVersionChange
+
+func (s majorVersionChangeSlice) String() string {
+	if len(s) == 0 {
+		return fmt.Sprintf("No major YANG version changes in commit %s", commitSHA)
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Major YANG version changes in commit %s:\n", commitSHA))
+	for _, change := range s {
+		b.WriteString(fmt.Sprintf("%s: `%s` -> `%s`\n", change.File, change.OldVersion, change.NewVersion))
+	}
+	return b.String()
+}
+
+func (s majorVersionChangeSlice) hasBreaking() bool {
+	for _, change := range s {
+		if change.OldMajorVersion != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// processMiscChecksOutput takes the raw result output from the misc-checks
+// results directory and returns its formatted report and pass/fail status.
+//
+// It also returns a newline-separated string of the list of all YANG files
+// that have their major versions updated.
+func processMiscChecksOutput(resultsDir string) (string, bool, majorVersionChangeSlice, error) {
+	fileProperties := map[string]map[string]string{}
+	changedFiles, err := readYangFilesList(filepath.Join(resultsDir, "changed-files.txt"))
+	if err != nil {
+		return "", false, nil, err
+	}
+	for _, file := range changedFiles {
+		if _, ok := fileProperties[file]; !ok {
+			fileProperties[file] = map[string]string{}
+		}
+		fileProperties[file]["changed"] = "true"
+	}
+	if err := readGoyangVersionsLog(filepath.Join(resultsDir, "pr-file-parse-log"), false, fileProperties); err != nil {
+		return "", false, nil, err
+	}
+	if err := readGoyangVersionsLog(filepath.Join(resultsDir, "master-file-parse-log"), true, fileProperties); err != nil {
+		return "", false, nil, err
+	}
+
+	var ocVersionViolations []string
+	ocVersionChangedCount := 0
+	var reachabilityViolations []string
+	filesReachedCount := 0
+	// Only look at the PR's files as they might be different from the master's files.
+	allNonEmptyPRFiles, err := readYangFilesList(filepath.Join(resultsDir, "all-non-empty-files.txt"))
+	if err != nil {
+		return "", false, nil, err
+	}
+	moduleFileGroups := map[string][]fileAndVersion{}
+	var majorVersionChanges majorVersionChangeSlice
+	for _, file := range allNonEmptyPRFiles {
+		properties, ok := fileProperties[file]
+
+		// Reachability check
+		if !ok || properties["reachable"] != "true" {
+			reachabilityViolations = append(reachabilityViolations, sprintLineHTML("%s: file not used by any .spec.yml build.", file))
+			// If the file was not reached, then its other
+			// parameters would not have been parsed by goyang, so
+			// simply skip the rest of the checks.
+			continue
+		}
+		filesReachedCount += 1
+
+		// openconfig-version update check
+		ocVersion, hasVersion := properties["openconfig-version"]
+		masterOcVersion, hadVersion := properties["master-openconfig-version"]
+		switch {
+		case properties["changed"] != "true":
+			// We assume the versioning is correct without change.
+		case hadVersion && hasVersion:
+			oldver, newver, err := checkSemverIncrease(masterOcVersion, ocVersion, "openconfig-version")
+			if err != nil {
+				ocVersionViolations = append(ocVersionViolations, sprintLineHTML(file+": "+err.Error()))
+			} else {
+				ocVersionChangedCount += 1
+			}
+			if oldver != nil && newver != nil {
+				if oldver.Major() != newver.Major() {
+					majorVersionChanges = append(majorVersionChanges, majorVersionChange{
+						File:            file,
+						OldMajorVersion: oldver.Major(),
+						OldVersion:      masterOcVersion,
+						NewVersion:      ocVersion,
+					})
+				}
+			}
+		case hadVersion && !hasVersion:
+			ocVersionViolations = append(ocVersionViolations, sprintLineHTML("%s: openconfig-version was removed", file))
+		default: // If didn't have version before, any new version is accepted.
+			ocVersionChangedCount += 1
+		}
+
+		if mod, ok := properties["belonging-module"]; hasVersion && ok {
+			// Error checking is already done by the version update check.
+			if v, err := semver.StrictNewVersion(ocVersion); err == nil {
+				moduleFileGroups[mod] = append(moduleFileGroups[mod], fileAndVersion{name: file, version: v})
+			}
+		}
+	}
+
+	// Compute HTML string and pass/fail status.
+	var out strings.Builder
+	var pass = true
+	appendViolationOut := func(desc string, violations []string, passString string) {
+		if len(violations) == 0 {
+			out.WriteString(sprintSummaryHTML(commonci.BoolStatusToString(true), desc, passString))
+		} else {
+			out.WriteString(sprintSummaryHTML(commonci.BoolStatusToString(false), desc, strings.Join(violations, "")))
+			pass = false
+		}
+	}
+	appendViolationOut("openconfig-version update check", ocVersionViolations, fmt.Sprintf("%d file(s) correctly updated.\n", ocVersionChangedCount))
+	appendViolationOut(".spec.yml build reachability check", reachabilityViolations, fmt.Sprintf("%d files reached by build rules.\n", filesReachedCount))
+	appendViolationOut("submodule versions must match the belonging module's version", versionGroupViolationsHTML(moduleFileGroups), fmt.Sprintf("%d module/submodule file groups have matching versions", len(moduleFileGroups)))
+
+	return out.String(), pass, majorVersionChanges, nil
+}


### PR DESCRIPTION
Move `processMiscChecksOutput` to new file.

Created new struct `versionRecord` to represent version changes and refactored code to use it.

Working at https://github.com/openconfig/public/pull/842