### PR TITLE
Improve comment for when the -pr-number flag is not provided.

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -465,7 +465,7 @@ func main() {
 	// If it's a push on master, just upload badge for normal validators as the only action.
 	if prNumber == 0 {
 		if branchName != "master" {
-			log.Fatalf("cmd_gen: There is no action to take for a non-master branch push, please re-examine your push triggers")
+			log.Fatalf("cmd_gen: pr-number not supplied as a flag to the build. Try re-running (by commenting \"/gcbrun\" on the GitHub PR) to see whether the $_PR_NUMBER substitution variable for Google Cloud Build gets passed into the build. If this branch is not associated with a PR, then it is inferred that this is a non-master branch push action, and thus there is no CI action that is expected, and in this case please re-examine your push triggers.")
 		}
 		pushToMaster = true
 	}


### PR DESCRIPTION
Sometimes the substitution variable is not supplied: https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions

See https://github.com/openconfig/public/pull/783#issuecomment-1507637198