### PR TITLE
Speed up pyangbind and compile generated Python file

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -192,14 +192,15 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
-  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
+  local output_file="$1"."$2".binding.py
+  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "${output_file}" "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "${output_file}" "${options[@]}" )
   shift 2
   echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
-    python "$1"."$2".binding.py || status=1
+    python "${output_file}" || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -196,7 +196,12 @@ function run-dir() {
   local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
   echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
-  if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
+  status=0
+  $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
+  if [[ $status -eq "0" ]]; then
+    python "$1"."$2".binding.py || status=1
+  fi
+  if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail
   fi
 }
@@ -345,6 +350,7 @@ type labelPoster interface {
 //     will be run only on a single model as specified in the .spec.yml file.
 //  2. Thus, a validation command and result is provided for each model.
 //  3. A file indicating pass/fail is output for each model into the given result directory.
+//
 // Files names follow the "modelDir==model==status" format with no file extensions.
 // The local flag indicates to run this as a helper to generate the script,
 // rather than running it within GCB.

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -200,7 +200,7 @@ function run-dir() {
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
-    python "${output_file}" || status=1
+    python "${output_file}" &> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -166,7 +166,7 @@ function run-dir() {
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
-    python "${output_file}" || status=1
+    python "${output_file}" &> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -162,7 +162,12 @@ function run-dir() {
   local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
   shift 2
   echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
-  if ! $($cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass); then
+  status=0
+  $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
+  if [[ $status -eq "0" ]]; then
+    python "$1"."$2".binding.py || status=1
+  fi
+  if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail
   fi
 }

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -158,14 +158,15 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "$1"."$2".binding.py "${options[@]}" )
-  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "$1"."$2".binding.py "${options[@]}" )
+  local output_file="$1"."$2".binding.py
+  local cmd_display_options=( --plugindir '$PYANGBIND_PLUGIN_DIR' -o "${output_file}" "${options[@]}" )
+  local options=( --plugindir "$PYANGBIND_PLUGIN_DIR" -o "${output_file}" "${options[@]}" )
   shift 2
   echo pyang "${cmd_display_options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
-    python "$1"."$2".binding.py || status=1
+    python "${output_file}" || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/validators/pyangbind/test.sh
+++ b/validators/pyangbind/test.sh
@@ -47,6 +47,7 @@ setup
 pip3 list | grep pyangbind > $RESULTSDIR/latest-version.txt
 find $RESULTSDIR/latest-version.txt -size 0 -delete
 
+export PYTHONPATH="${PYTHONPATH}:${PYANGBIND_REPO}"
 export PYANGBIND_PLUGIN_DIR="${PYANGBIND_REPO}/pyangbind/plugin"
 if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.

--- a/validators/pyangbind/test.sh
+++ b/validators/pyangbind/test.sh
@@ -34,7 +34,6 @@ setup() {
 
   git clone https://github.com/robshakir/pyangbind $PYANGBIND_REPO
   pip3 install --no-cache-dir -r $PYANGBIND_REPO/requirements.txt
-  pip3 install pyangbind
   pip3 install pyang
 }
 
@@ -48,8 +47,7 @@ setup
 pip3 list | grep pyangbind > $RESULTSDIR/latest-version.txt
 find $RESULTSDIR/latest-version.txt -size 0 -delete
 
-export PYANGBIND_PLUGIN_DIR=`/usr/bin/env python3 -c \
-  'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
+export PYANGBIND_PLUGIN_DIR="${PYANGBIND_REPO}/pyangbind/plugin"
 if bash $RESULTSDIR/script.sh $VENVDIR/bin/pyang > $OUTFILE 2> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete


### PR DESCRIPTION
Using the local pyangbind plugin dir instead of the version in PyPI (via pip) speeds up pyangbind code generation.

Also I noticed we were not compiling/interpreting the generated Python file all this time, so do that.