### PR TITLE
Incorporate `go install` CI step in test.sh

### DIFF
--- a/validators/goyang-ygot/test.sh
+++ b/validators/goyang-ygot/test.sh
@@ -23,7 +23,10 @@ if ! stat $RESULTSDIR; then
   exit 0
 fi
 
-go install github.com/openconfig/ygot/generator@latest > "${OUTFILE}" 2> "${FAILFILE}"
+# module download logs go to stderr, so only fail if command failed.
+if ! go install github.com/openconfig/ygot/generator@latest &> "${OUTFILE}"; then
+  echo "failed: go install github.com/openconfig/ygot/generator@latest" > "${FAILFILE}"
+fi
 
 go list -m github.com/openconfig/ygot@latest > $RESULTSDIR/latest-version.txt
 if bash $RESULTSDIR/script.sh >> $OUTFILE 2>> $FAILFILE; then

--- a/validators/goyang-ygot/test.sh
+++ b/validators/goyang-ygot/test.sh
@@ -23,8 +23,10 @@ if ! stat $RESULTSDIR; then
   exit 0
 fi
 
+go install github.com/openconfig/ygot/generator@latest > "${OUTFILE}" 2> "${FAILFILE}"
+
 go list -m github.com/openconfig/ygot@latest > $RESULTSDIR/latest-version.txt
-if bash $RESULTSDIR/script.sh > $OUTFILE 2> $FAILFILE; then
+if bash $RESULTSDIR/script.sh >> $OUTFILE 2>> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi


### PR DESCRIPTION
This is a minor change that moves a CI step into test.sh instead of cloudbuild.yaml. Failing in cloudbuild.yaml fails the whole pipeline and is undesirable.

**This is a backwards-incompatible change.**