### PR TITLE
Add ygnmi validator

### DIFF
--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -244,7 +244,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
-go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/cmd/goimports@latest &>> ${prefix}pass || status=1
 `),
 			perModelTemplate: mustTemplate("goyang-ygot", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -237,7 +237,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
-    goimports -w . &>> ${prefix}pass || status=1
+    goimports -w *.go &>> ${prefix}pass || status=1
     go build &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -276,7 +276,7 @@ function run-dir() {
     go mod init &> /dev/null || status=1
     go mod tidy &> /dev/null || status=1
     goimports -w *.go &> /dev/null || status=1
-    go build ./... &> /dev/null || status=1
+    go build &> /dev/null || status=1
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -228,7 +228,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygot/"$1"."$2"/
-  mkdir "$outdir"
+  mkdir -p "$outdir"
   local options=( -output_file="$outdir"/oc.go "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
@@ -265,7 +265,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygnmi/"$1"."$2"
-  mkdir "$outdir"
+  mkdir -p "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -244,7 +244,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
-go install golang.org/x/tools/cmd/goimports@latesn
+go install golang.org/x/tools/cmd/goimports@latest
 `),
 			perModelTemplate: mustTemplate("goyang-ygot", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -244,6 +244,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
+go install golang.org/x/tools/cmd/goimports@latest
 `),
 			perModelTemplate: mustTemplate("goyang-ygot", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -233,8 +233,8 @@ function run-dir() {
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
-  cd "$outdir/oc"
   if [[ $status -eq "0" ]]; then
+    cd "$outdir/oc"
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -273,12 +273,17 @@ function run-dir() {
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
     cd "$outdir/oc"
+    go mod init &> /dev/null || status=1
+    go mod tidy &> /dev/null || status=1
+    goimports -w . &> /dev/null || status=1
+    go build ./... &> /dev/null || status=1
+  fi
+  if [[ $status -eq "1" ]]; then
+    # Only output if there is an error: otherwise the gist comment is too long.
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
-  fi
-  if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail
   fi
 }

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -227,7 +227,7 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"/
+  outdir=$GOPATH/src/ygot/"$1"."$2"/
   mkdir "$outdir"
   local options=( -output_file="$outdir"/oc.go "${options[@]}" )
   shift 2
@@ -264,7 +264,7 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"
+  outdir=$GOPATH/src/ygnmi/"$1"."$2"
   mkdir "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
@@ -276,7 +276,7 @@ function run-dir() {
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1
-    go build &>> ${prefix}pass || status=1
+    go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -233,12 +233,12 @@ function run-dir() {
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
-  cd "$outdir"
+  cd "$outdir/oc"
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w . &>> ${prefix}pass || status=1
-    go build ./... &>> ${prefix}pass || status=1
+    go build &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -302,7 +302,7 @@ fi
 // runInParallel determines whether a particular validator and version should be run in parallel.
 func runInParallel(validatorId, version string) bool {
 	switch {
-	case validatorId == "goyang-ygot", validatorId == "pyang" && version == "head":
+	case validatorId == "pyang" && version == "head":
 		return false
 	default:
 		return true

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -214,14 +214,13 @@ function run-dir() {
 			headerTemplate: mustTemplate("goyang-ygot-header", `#!/bin/bash
 workdir={{ .ResultsDir }}
 mkdir -p "$workdir"
-cmd="generator"
+cmd="ygnmi generator"
 options=(
-  -path={{ .ModelRoot }},{{ .RepoRoot }}/third_party/ietf
-  -package_name=exampleoc -generate_fakeroot -fakeroot_name=device -compress_paths=true
-  -shorten_enum_leaf_names -trim_enum_openconfig_prefix -typedef_enum_with_defmod -enum_suffix_for_simple_union_enums
-  -exclude_modules=ietf-interfaces -generate_rename -generate_append -generate_getters
-  -generate_leaf_getters -generate_delete -annotations -generate_simple_unions
-  -list_builder_key_threshold=3
+  --trim_module_prefix=openconfig
+  --exclude_modules=ietf-interfaces
+  --split_package_paths="/network-instances/network-instance/protocols/protocol/isis=netinstisis,/network-instances/network-instance/protocols/protocol/bgp=netinstbgp"
+  --paths={{ .ModelRoot }},{{ .RepoRoot }}/third_party/ietf
+  --annotations
 )
 script_options=(
 )
@@ -229,7 +228,7 @@ function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/"$1"."$2"/
   mkdir "$outdir"
-  local options=( -output_file="$outdir"/oc.go "${options[@]}" )
+  local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
@@ -238,7 +237,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
-    go build &>> ${prefix}pass || status=1
+    go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -275,7 +275,7 @@ function run-dir() {
     cd "$outdir/oc"
     go mod init &> /dev/null || status=1
     go mod tidy &> /dev/null || status=1
-    goimports -w . &> /dev/null || status=1
+    goimports -w *.go &> /dev/null || status=1
     go build ./... &> /dev/null || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -302,7 +302,7 @@ fi
 // runInParallel determines whether a particular validator and version should be run in parallel.
 func runInParallel(validatorId, version string) bool {
 	switch {
-	case validatorId == "pyang" && version == "head":
+	case validatorId == "goyang-ygot", validatorId == "pyang" && version == "head":
 		return false
 	default:
 		return true

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -219,14 +219,14 @@ options=(
   --trim_module_prefix=openconfig
   --exclude_modules=ietf-interfaces
   --split_package_paths="/network-instances/network-instance/protocols/protocol/isis=netinstisis,/network-instances/network-instance/protocols/protocol/bgp=netinstbgp"
-  --paths={{ .ModelRoot }},{{ .RepoRoot }}/third_party/ietf
+  --paths={{ .ModelRoot }}/...,{{ .RepoRoot }}/third_party/ietf/...
   --annotations
 )
 script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"/
+  outdir=$GOPATH/src/"$1"."$2"
   mkdir "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
@@ -237,6 +237,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
+    goimports -w . &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -266,7 +266,7 @@ function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygnmi/"$1"."$2"
   mkdir -p "$outdir"
-  local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
+  local options=( --output_dir="${outdir}"/oc --base_package_path=ygnmi/"$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
@@ -280,9 +280,6 @@ function run-dir() {
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.
-    go mod init &>> ${prefix}pass || status=1
-    go mod tidy &>> ${prefix}pass || status=1
-    goimports -w *.go &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -280,7 +280,7 @@ function run-dir() {
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.
-    go build ./... &>> ${prefix}pass || status=1
+    go build &>> ${prefix}pass || status=1
     mv ${prefix}pass ${prefix}fail
   fi
 }

--- a/cmd_gen/main.go
+++ b/cmd_gen/main.go
@@ -244,7 +244,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
-go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/cmd/goimports@latesn
 `),
 			perModelTemplate: mustTemplate("goyang-ygot", `run-dir "{{ .ModelDirName }}" "{{ .ModelName }}" {{- range $i, $buildFile := .BuildFiles }} {{ $buildFile }} {{- end }} {{- if .Parallel }} & {{- end }}
 `),
@@ -302,7 +302,7 @@ fi
 // runInParallel determines whether a particular validator and version should be run in parallel.
 func runInParallel(validatorId, version string) bool {
 	switch {
-	case validatorId == "goyang-ygot", validatorId == "pyang" && version == "head":
+	case validatorId == "pyang" && version == "head":
 		return false
 	default:
 		return true

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -184,6 +184,48 @@ wait
 		wantCmd: `#!/bin/bash
 workdir=/workspace/results/goyang-ygot
 mkdir -p "$workdir"
+cmd="generator"
+options=(
+  -path=testdata,/workspace/third_party/ietf
+  -package_name=exampleoc -generate_fakeroot -fakeroot_name=device -compress_paths=true
+  -shorten_enum_leaf_names -trim_enum_openconfig_prefix -typedef_enum_with_defmod -enum_suffix_for_simple_union_enums
+  -exclude_modules=ietf-interfaces -generate_rename -generate_append -generate_getters
+  -generate_leaf_getters -generate_delete -annotations -generate_simple_unions
+  -list_builder_key_threshold=3
+)
+script_options=(
+)
+function run-dir() {
+  declare prefix="$workdir"/"$1"=="$2"==
+  outdir=$GOPATH/src/"$1"."$2"/
+  mkdir "$outdir"
+  local options=( -output_file="$outdir"/oc.go "${options[@]}" )
+  shift 2
+  echo $cmd "${options[@]}" "$@" > ${prefix}cmd
+  status=0
+  $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
+  cd "$outdir"
+  if [[ $status -eq "0" ]]; then
+    go mod init &>> ${prefix}pass || status=1
+    go mod tidy &>> ${prefix}pass || status=1
+    go build &>> ${prefix}pass || status=1
+  fi
+  if [[ $status -eq "1" ]]; then
+    mv ${prefix}pass ${prefix}fail
+  fi
+}
+run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang &
+run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang &
+run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang &
+wait
+`,
+	}, {
+		name:            "basic ygnmi",
+		inModelMap:      basicModelMap,
+		inValidatorName: "ygnmi",
+		wantCmd: `#!/bin/bash
+workdir=/workspace/results/ygnmi
+mkdir -p "$workdir"
 cmd="ygnmi generator"
 options=(
   --trim_module_prefix=openconfig

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -250,7 +250,7 @@ function run-dir() {
     go mod init &> /dev/null || status=1
     go mod tidy &> /dev/null || status=1
     goimports -w *.go &> /dev/null || status=1
-    go build ./... &> /dev/null || status=1
+    go build &> /dev/null || status=1
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -247,12 +247,17 @@ function run-dir() {
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
   if [[ $status -eq "0" ]]; then
     cd "$outdir/oc"
+    go mod init &> /dev/null || status=1
+    go mod tidy &> /dev/null || status=1
+    goimports -w . &> /dev/null || status=1
+    go build ./... &> /dev/null || status=1
+  fi
+  if [[ $status -eq "1" ]]; then
+    # Only output if there is an error: otherwise the gist comment is too long.
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
-  fi
-  if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail
   fi
 }

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -240,7 +240,7 @@ function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygnmi/"$1"."$2"
   mkdir -p "$outdir"
-  local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
+  local options=( --output_dir="${outdir}"/oc --base_package_path=ygnmi/"$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
@@ -254,9 +254,6 @@ function run-dir() {
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.
-    go mod init &>> ${prefix}pass || status=1
-    go mod tidy &>> ${prefix}pass || status=1
-    goimports -w *.go &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
     mv ${prefix}pass ${prefix}fail
   fi

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -215,9 +215,9 @@ function run-dir() {
   fi
 }
 go install golang.org/x/tools/cmd/goimports@latest
-run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang
-run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang
-run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang
+run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang &
+run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang &
+run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang &
 wait
 `,
 	}, {

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -198,7 +198,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygot/"$1"."$2"/
-  mkdir "$outdir"
+  mkdir -p "$outdir"
   local options=( -output_file="$outdir"/oc.go "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
@@ -239,7 +239,7 @@ script_options=(
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/ygnmi/"$1"."$2"
-  mkdir "$outdir"
+  mkdir -p "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -203,8 +203,8 @@ function run-dir() {
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
-  cd "$outdir/oc"
   if [[ $status -eq "0" ]]; then
+    cd "$outdir/oc"
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -254,7 +254,7 @@ function run-dir() {
   fi
   if [[ $status -eq "1" ]]; then
     # Only output if there is an error: otherwise the gist comment is too long.
-    go build ./... &>> ${prefix}pass || status=1
+    go build &>> ${prefix}pass || status=1
     mv ${prefix}pass ${prefix}fail
   fi
 }

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -215,9 +215,9 @@ function run-dir() {
   fi
 }
 go install golang.org/x/tools/cmd/goimports@latest &>> ${prefix}pass || status=1
-run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang
-run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang
-run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang
+run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang &
+run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang &
+run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang &
 wait
 `,
 	}, {

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -207,7 +207,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
-    goimports -w . &>> ${prefix}pass || status=1
+    goimports -w *.go &>> ${prefix}pass || status=1
     go build &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -184,14 +184,13 @@ wait
 		wantCmd: `#!/bin/bash
 workdir=/workspace/results/goyang-ygot
 mkdir -p "$workdir"
-cmd="generator"
+cmd="ygnmi generator"
 options=(
-  -path=testdata,/workspace/third_party/ietf
-  -package_name=exampleoc -generate_fakeroot -fakeroot_name=device -compress_paths=true
-  -shorten_enum_leaf_names -trim_enum_openconfig_prefix -typedef_enum_with_defmod -enum_suffix_for_simple_union_enums
-  -exclude_modules=ietf-interfaces -generate_rename -generate_append -generate_getters
-  -generate_leaf_getters -generate_delete -annotations -generate_simple_unions
-  -list_builder_key_threshold=3
+  --trim_module_prefix=openconfig
+  --exclude_modules=ietf-interfaces
+  --split_package_paths="/network-instances/network-instance/protocols/protocol/isis=netinstisis,/network-instances/network-instance/protocols/protocol/bgp=netinstbgp"
+  --paths=testdata,/workspace/third_party/ietf
+  --annotations
 )
 script_options=(
 )
@@ -199,7 +198,7 @@ function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
   outdir=$GOPATH/src/"$1"."$2"/
   mkdir "$outdir"
-  local options=( -output_file="$outdir"/oc.go "${options[@]}" )
+  local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
@@ -208,7 +207,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
-    go build &>> ${prefix}pass || status=1
+    go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -203,12 +203,12 @@ function run-dir() {
   echo $cmd "${options[@]}" "$@" > ${prefix}cmd
   status=0
   $cmd "${options[@]}" "${script_options[@]}" "$@" &> ${prefix}pass || status=1
-  cd "$outdir"
+  cd "$outdir/oc"
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w . &>> ${prefix}pass || status=1
-    go build ./... &>> ${prefix}pass || status=1
+    go build &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -214,7 +214,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
-go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/cmd/goimports@latest &>> ${prefix}pass || status=1
 run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang
 run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang
 run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -214,6 +214,7 @@ function run-dir() {
     mv ${prefix}pass ${prefix}fail
   fi
 }
+go install golang.org/x/tools/cmd/goimports@latest
 run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang
 run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang
 run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -249,7 +249,7 @@ function run-dir() {
     cd "$outdir/oc"
     go mod init &> /dev/null || status=1
     go mod tidy &> /dev/null || status=1
-    goimports -w . &> /dev/null || status=1
+    goimports -w *.go &> /dev/null || status=1
     go build ./... &> /dev/null || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -197,7 +197,7 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"/
+  outdir=$GOPATH/src/ygot/"$1"."$2"/
   mkdir "$outdir"
   local options=( -output_file="$outdir"/oc.go "${options[@]}" )
   shift 2
@@ -238,7 +238,7 @@ script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"
+  outdir=$GOPATH/src/ygnmi/"$1"."$2"
   mkdir "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
@@ -250,7 +250,7 @@ function run-dir() {
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
     goimports -w *.go &>> ${prefix}pass || status=1
-    go build &>> ${prefix}pass || status=1
+    go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then
     mv ${prefix}pass ${prefix}fail

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -215,9 +215,9 @@ function run-dir() {
   fi
 }
 go install golang.org/x/tools/cmd/goimports@latest
-run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang &
-run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang &
-run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang &
+run-dir "acl" "openconfig-acl" testdata/acl/openconfig-acl.yang testdata/acl/openconfig-acl-evil-twin.yang
+run-dir "optical-transport" "openconfig-optical-amplifier" testdata/optical-transport/openconfig-optical-amplifier.yang
+run-dir "optical-transport" "openconfig-transport-line-protection" testdata/optical-transport/openconfig-transport-line-protection.yang
 wait
 `,
 	}, {

--- a/cmd_gen/main_test.go
+++ b/cmd_gen/main_test.go
@@ -189,14 +189,14 @@ options=(
   --trim_module_prefix=openconfig
   --exclude_modules=ietf-interfaces
   --split_package_paths="/network-instances/network-instance/protocols/protocol/isis=netinstisis,/network-instances/network-instance/protocols/protocol/bgp=netinstbgp"
-  --paths=testdata,/workspace/third_party/ietf
+  --paths=testdata/...,/workspace/third_party/ietf/...
   --annotations
 )
 script_options=(
 )
 function run-dir() {
   declare prefix="$workdir"/"$1"=="$2"==
-  outdir=$GOPATH/src/"$1"."$2"/
+  outdir=$GOPATH/src/"$1"."$2"
   mkdir "$outdir"
   local options=( --output_dir="${outdir}"/oc --base_package_path="$1"."$2"/oc "${options[@]}" )
   shift 2
@@ -207,6 +207,7 @@ function run-dir() {
   if [[ $status -eq "0" ]]; then
     go mod init &>> ${prefix}pass || status=1
     go mod tidy &>> ${prefix}pass || status=1
+    goimports -w . &>> ${prefix}pass || status=1
     go build ./... &>> ${prefix}pass || status=1
   fi
   if [[ $status -eq "1" ]]; then

--- a/commonci/commonci.go
+++ b/commonci/commonci.go
@@ -154,6 +154,11 @@ var (
 			IsPerModel:       true,
 			IsWidelyUsedTool: true,
 		},
+		"ygnmi": {
+			Name:             "ygnmi",
+			IsPerModel:       true,
+			IsWidelyUsedTool: true,
+		},
 		"yanglint": {
 			Name:             "yanglint",
 			IsPerModel:       true,

--- a/commonci/github.go
+++ b/commonci/github.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -101,6 +102,10 @@ func (g *GithubRequestHandler) AddGistComment(gistID, title, output string) (int
 	defer cancel() // cancel context if the function returns before the timeout
 
 	gistComment := fmt.Sprintf("# %s\n%s", title, output)
+	if bs := []byte(gistComment); len(bs) > math.MaxUint16 {
+		log.Printf("Truncating gist comment from %d bytes to %d bytes", len(bs), math.MaxUint16)
+		gistComment = string(bs[:math.MaxUint16])
+	}
 
 	var id int64
 	if err := Retry(5, "gist comment creation", func() error {

--- a/validators/goyang-ygot/test.sh
+++ b/validators/goyang-ygot/test.sh
@@ -24,11 +24,11 @@ if ! stat $RESULTSDIR; then
 fi
 
 # module download logs go to stderr, so only fail if command failed.
-if ! go install github.com/openconfig/ygot/generator@latest &> "${OUTFILE}"; then
-  echo "failed: go install github.com/openconfig/ygot/generator@latest" > "${FAILFILE}"
+if ! go install github.com/openconfig/ygnmi/app/ygnmi@latest &> "${OUTFILE}"; then
+  echo "failed: go install github.com/openconfig/ygnmi/app/ygnmi@latest" > "${FAILFILE}"
 fi
 
-go list -m github.com/openconfig/ygot@latest > $RESULTSDIR/latest-version.txt
+go list -m github.com/openconfig/ygnmi@latest > $RESULTSDIR/latest-version.txt
 if bash $RESULTSDIR/script.sh >> $OUTFILE 2>> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete

--- a/validators/ygnmi/test.sh
+++ b/validators/ygnmi/test.sh
@@ -15,7 +15,7 @@
 
 
 ROOT_DIR=/workspace
-RESULTSDIR=$ROOT_DIR/results/goyang-ygot
+RESULTSDIR=$ROOT_DIR/results/ygnmi
 OUTFILE=$RESULTSDIR/out
 FAILFILE=$RESULTSDIR/fail
 
@@ -24,16 +24,16 @@ if ! stat $RESULTSDIR; then
 fi
 
 # module download logs go to stderr, so only fail if command failed.
-if ! go install github.com/openconfig/ygot/generator@latest &> "${OUTFILE}"; then
-  echo "failed: go install github.com/openconfig/ygot/generator@latest" > "${FAILFILE}"
+if ! go install github.com/openconfig/ygnmi/app/ygnmi@latest &> "${OUTFILE}"; then
+  echo "failed: go install github.com/openconfig/ygnmi/app/ygnmi@latest" > "${FAILFILE}"
 fi
 
-go list -m github.com/openconfig/ygot@latest > $RESULTSDIR/latest-version.txt
+go list -m github.com/openconfig/ygnmi@latest > $RESULTSDIR/latest-version.txt
 if bash $RESULTSDIR/script.sh >> $OUTFILE 2>> $FAILFILE; then
   # Delete fail file if it's empty and the script passed.
   find $FAILFILE -size 0 -delete
 fi
-$GOPATH/bin/post_results -validator=goyang-ygot -modelRoot=$_MODEL_ROOT -repo-slug=$_REPO_SLUG -pr-number=$_PR_NUMBER -commit-sha=$COMMIT_SHA -branch=$BRANCH_NAME
+$GOPATH/bin/post_results -validator=ygnmi -modelRoot=$_MODEL_ROOT -repo-slug=$_REPO_SLUG -pr-number=$_PR_NUMBER -commit-sha=$COMMIT_SHA -branch=$BRANCH_NAME
 BADGEFILE=$RESULTSDIR/upload-badge.sh
 if stat $BADGEFILE; then
   bash $BADGEFILE


### PR DESCRIPTION
* Only compile ygot-generated code since ygnmi-generated code significantly increases compilation time and it is simpler so most issues will be caught at code-generation time.
* Make processing parallel, which reduced stage time from 7m2.326s to 1m26.953s

Tested @ https://github.com/openconfig/public/pull/996 (see latest commits)