### PR TITLE
Do not report type updates as invalid when incompatibilities are allowed

### DIFF
--- a/openconfig-ci/ocdiff/testdata/disallowed-incompats.txt
+++ b/openconfig-ci/ocdiff/testdata/disallowed-incompats.txt
@@ -1,7 +1,2 @@
 leaf deleted: /openconfig-platform/components/component/linecard/state/slot-id ("openconfig-platform-linecard": openconfig-version 1.1.0 -> 1.2.0)
-leaf updated: /openconfig-platform/components/component/chassis/utilization/resources/resource/state/used: type changed from uint64 to uint32 ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
-leaf updated: /openconfig-platform/components/component/integrated-circuit/utilization/resources/resource/state/used: type changed from uint64 to uint32 ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
 leaf updated: /openconfig-platform/components/component/linecard/state/colour: type changed from string to binary ("openconfig-platform-linecard": openconfig-version 1.1.0 -> 1.2.0)
-leaf updated: /openconfig-platform/components/component/linecard/utilization/resources/resource/state/used: type changed from uint64 to uint32 ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
-leaf updated: /openconfig-platform/components/component/port/breakout-mode/groups/group/config/num-physical-channels: type changed from uint8 to uint16 ("openconfig-platform-port": openconfig-version 1.0.1 -> 2.0.0)
-leaf updated: /openconfig-platform/components/component/port/breakout-mode/groups/group/state/num-physical-channels: type changed from uint8 to uint16 ("openconfig-platform-port": openconfig-version 1.0.1 -> 2.0.0)

--- a/openconfig-ci/ocdiff/testdata/github-comment-disallowed-incompats.txt
+++ b/openconfig-ci/ocdiff/testdata/github-comment-disallowed-incompats.txt
@@ -1,27 +1,7 @@
 leaf deleted: `/openconfig-platform/components/component/linecard/state/slot-id`
 * ("openconfig-platform-linecard": openconfig-version 1.1.0 -> 1.2.0)
 
-leaf updated: `/openconfig-platform/components/component/chassis/utilization/resources/resource/state/used`
-* type changed from uint64 to uint32
-* ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
-
-leaf updated: `/openconfig-platform/components/component/integrated-circuit/utilization/resources/resource/state/used`
-* type changed from uint64 to uint32
-* ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
-
 leaf updated: `/openconfig-platform/components/component/linecard/state/colour`
 * type changed from string to binary
 * ("openconfig-platform-linecard": openconfig-version 1.1.0 -> 1.2.0)
-
-leaf updated: `/openconfig-platform/components/component/linecard/utilization/resources/resource/state/used`
-* type changed from uint64 to uint32
-* ("openconfig-platform": openconfig-version 0.23.0 -> 0.24.0)
-
-leaf updated: `/openconfig-platform/components/component/port/breakout-mode/groups/group/config/num-physical-channels`
-* type changed from uint8 to uint16
-* ("openconfig-platform-port": openconfig-version 1.0.1 -> 2.0.0)
-
-leaf updated: `/openconfig-platform/components/component/port/breakout-mode/groups/group/state/num-physical-channels`
-* type changed from uint8 to uint16
-* ("openconfig-platform-port": openconfig-version 1.0.1 -> 2.0.0)
 


### PR DESCRIPTION
Currently breaking type changes are always reported as invalid. This change skips reporting them when version update permits, similar to deleted paths.

This was likely an oversight when creating the test cases since it was done correctly for path deletions.