### PR TITLE
Dont omit output when script fails

### DIFF
--- a/post_results/main.go
+++ b/post_results/main.go
@@ -347,7 +347,7 @@ func getResult(validatorId, resultsDir string, condensed bool) (string, bool, ve
 	case validator.IsPerModel:
 		outString, pass, err = parseModelResultsHTML(validatorId, resultsDir, condensed)
 		if pass && condensed {
-			outString = "All passed.\n" + outString
+			outString = "All models passed.\n" + outString
 		}
 	case !executionFailed:
 		outString = "Test passed."
@@ -373,7 +373,11 @@ func getResult(validatorId, resultsDir string, condensed bool) (string, bool, ve
 			err = nil
 		}
 
-		outString = failString + "\n\n" + outString
+		if outString != "" {
+			outString = failString + "\n" + outString
+		} else {
+			outString = failString
+		}
 	}
 
 	return outString, pass, versionRecords, err

--- a/post_results/main_test.go
+++ b/post_results/main_test.go
@@ -309,7 +309,7 @@ Passed.
 </details>
 </details>
 `,
-		wantCondensedOut: `All passed.
+		wantCondensedOut: `All models passed.
 `,
 	}, {
 		name:                 "pyang with an empty fail file",
@@ -319,8 +319,35 @@ Passed.
 		wantOut: `Validator script failed -- infra bug?
 ` + "```" + `
 Test failed with no stderr output.
-` + "```",
-		wantCondensedOutSame: true,
+` + "```" + `
+<details>
+  <summary>&#x2705;&nbsp; acl</summary>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-acl</summary>
+Passed.
+</details>
+</details>
+<details>
+  <summary>&#x2705;&nbsp; optical-transport</summary>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-optical-amplifier</summary>
+Passed.
+</details>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-transport-line-protection</summary>
+Passed.
+<ul>
+  <pre>warning foo</pre>
+</ul>
+</details>
+</details>
+`,
+		wantCondensedOut: `Validator script failed -- infra bug?
+` + "```" + `
+Test failed with no stderr output.
+` + "```" + `
+All models passed.
+`,
 	}, {
 		name:                 "basic non-pyang pass",
 		inValidatorResultDir: "testdata/oc-pyang",
@@ -352,7 +379,7 @@ warning foo<br>
 </details>
 </details>
 `,
-		wantCondensedOut: `All passed.
+		wantCondensedOut: `All models passed.
 `,
 	}, {
 		name:                 "pyang with pass and fails",
@@ -512,8 +539,32 @@ Failed.
 		inValidatorResultDir: "testdata/oc-pyang-script-fail",
 		inValidatorId:        "oc-pyang",
 		wantPass:             false,
-		wantOut:              "Validator script failed -- infra bug?\n```\nI failed\n\n```",
-		wantCondensedOutSame: true,
+		wantOut: "Validator script failed -- infra bug?\n```\nI failed\n\n```" + `
+<details>
+  <summary>&#x2705;&nbsp; acl</summary>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-acl</summary>
+Passed.
+</details>
+</details>
+<details>
+  <summary>&#x2705;&nbsp; optical-transport</summary>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-optical-amplifier</summary>
+Passed.
+</details>
+<details>
+  <summary>&#x2705;&nbsp; openconfig-transport-line-protection</summary>
+Passed.
+<ul>
+  <pre>warning foo</pre>
+</ul>
+</details>
+</details>
+`,
+		wantCondensedOut: "Validator script failed -- infra bug?\n```\nI failed\n\n```" + `
+All models passed.
+`,
 	}, {
 		name:                 "openconfig-version, revision version, and .spec.yml checks all pass",
 		inValidatorResultDir: "testdata/misc-checks-pass",


### PR DESCRIPTION
Previously when the whole script fails the individual models' results were being discarded. This makes debugging more difficult. Now append them to the script stderr output.

See results from https://github.com/openconfig/public/pull/1043

e.g. https://gist.github.com/OpenConfigBot/2b079ba55f45e202440eed488d274d1b, https://gist.github.com/OpenConfigBot/b0961781139bc51fc2d25c15942f2eb2